### PR TITLE
Remove responsibility of asserting exchanges from rpc/subscribers

### DIFF
--- a/packages/rabbitmq/src/amqp/AmqpConnection.ts
+++ b/packages/rabbitmq/src/amqp/AmqpConnection.ts
@@ -11,7 +11,7 @@ export interface CorrelationMessage {
   message: {};
 }
 
-interface MessageOptions {
+export interface MessageOptions {
   exchange: string;
   routingKey: string;
   queue?: string;
@@ -20,7 +20,7 @@ interface MessageOptions {
 const defaultConfig = {
   timeout: 10000,
   prefetchCount: 10,
-  exchangeType: 'topic'
+  defaultExchangeType: 'topic'
 };
 
 export class AmqpConnection {
@@ -48,7 +48,8 @@ export class AmqpConnection {
       this.config.exchanges.map(async x =>
         this._channel.assertExchange(
           x.name,
-          x.type || defaultConfig.exchangeType
+          x.type || this.config.defaultExchangeType,
+          x.options,
         )
       )
     );
@@ -90,12 +91,8 @@ export class AmqpConnection {
   public async createSubscriber<T>(
     handler: (msg: T) => Promise<void>,
     msgOptions: MessageOptions,
-    exchangeType: string = 'topic',
-    options?: amqplib.Options.AssertExchange
   ) {
     const { exchange, routingKey } = msgOptions;
-
-    await this._channel.assertExchange(exchange, exchangeType, options);
 
     const { queue } = await this.channel.assertQueue(msgOptions.queue || '');
 
@@ -116,12 +113,8 @@ export class AmqpConnection {
   public async createRpc<T, U>(
     handler: (msg: T) => Promise<U>,
     msgOptions: MessageOptions,
-    exchangeType: string = 'topic',
-    options?: amqplib.Options.AssertExchange
   ) {
     const { exchange, routingKey } = msgOptions;
-
-    await this._channel.assertExchange(exchange, exchangeType, options);
 
     const { queue } = await this.channel.assertQueue(msgOptions.queue || '');
 

--- a/packages/rabbitmq/src/index.ts
+++ b/packages/rabbitmq/src/index.ts
@@ -1,3 +1,6 @@
+export * from './amqp/AmqpConnection';
 export * from './rabbitmq.constants';
 export * from './rabbitmq.decorators';
+export * from './rabbitmq.interfaces';
 export * from './rabbitmq.module';
+

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -1,6 +1,9 @@
+import * as amqplib from 'amqplib';
+
 export interface RabbitMQExchangeConfig {
   name: string;
   type?: string;
+  options?: amqplib.Options.AssertExchange;
 }
 
 export interface RabbitMQConfig {
@@ -8,6 +11,7 @@ export interface RabbitMQConfig {
   timeout?: number;
   prefetchCount?: number;
   exchanges: RabbitMQExchangeConfig[];
+  defaultExchangeType?: string;
 }
 
 export type RabbitHandlerType = 'rpc' | 'subscribe';


### PR DESCRIPTION
- Extend exchange config to allow amqplib options
- Extend public API with index.tx exports
- Allowed setting the default exchange type externally