### PR TITLE
chore(jest-config): prevent processing js files as part of test run

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "jest": {
     "preset": "ts-jest",
     "transform": {
-      "^.+\\.(j|t)sx?$": "ts-jest"
+      "^.+\\.(t)sx?$": "ts-jest"
     },
     "projects": [
       "<rootDir>/packages/*"


### PR DESCRIPTION
fixes warning that was caused by jest pulling in js files

close #8