### PR TITLE
feat(rabbitmq): adds additional queue options

### DIFF
--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -101,7 +101,10 @@ export class AmqpConnection {
   ) {
     const { exchange, routingKey } = msgOptions;
 
-    const { queue } = await this.channel.assertQueue(msgOptions.queue || '');
+    const { queue } = await this.channel.assertQueue(
+      msgOptions.queue || '',
+      msgOptions.queueOptions || undefined
+    );
 
     await this.channel.bindQueue(queue, exchange, routingKey);
 

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -18,6 +18,11 @@ export interface RequestOptions {
   payload?: any;
 }
 
+export interface QueueOptions {
+  durable?: boolean;
+  exclusive?: boolean;
+}
+
 export enum MessageHandlerErrorBehavior {
   ACK,
   NACK,
@@ -28,6 +33,7 @@ export interface MessageHandlerOptions {
   exchange: string;
   routingKey: string;
   queue?: string;
+  queueOptions?: QueueOptions;
   errorBehavior?: MessageHandlerErrorBehavior;
 }
 


### PR DESCRIPTION
This enables subscribers to create "exclusive" and/or non-"durable"
queues.