### PR TITLE
fix(discovery): tolerate possibly null providers

### DIFF
--- a/packages/discovery/src/discovery.service.ts
+++ b/packages/discovery/src/discovery.service.ts
@@ -45,7 +45,7 @@ export const withMetaAtKey: (
   key: MetaKey
 ) => Filter<DiscoveredClass> = key => component => {
   const metaTargets: Function[] = [
-    component.instance.constructor,
+    get(component, 'instance.constructor'),
     component.injectType as Function
   ].filter(x => x != null);
 
@@ -174,6 +174,10 @@ export class DiscoveryService {
     metaKey: MetaKey
   ): DiscoveredMethodWithMeta<T>[] {
     const { instance } = component;
+
+    if (!instance) {
+      return [];
+    }
 
     const prototype = Object.getPrototypeOf(instance);
 

--- a/packages/discovery/src/tests/discovery.spec.ts
+++ b/packages/discovery/src/tests/discovery.spec.ts
@@ -15,6 +15,8 @@ const ExampleClassSymbol = Symbol('ExampleClassSymbol');
 
 const ExampleMethodSymbol = Symbol('ExampleMethodSymbol');
 
+const NullProviderSymbol = Symbol('NullProvider');
+
 const ExampleClassDecorator = (config: any) =>
   SetMetadata(ExampleClassSymbol, config);
 
@@ -40,7 +42,13 @@ class ExampleController {
 }
 
 @Module({
-  providers: [ExampleService],
+  providers: [
+    ExampleService,
+    {
+      provide: NullProviderSymbol,
+      useValue: null
+    }
+  ],
   controllers: [ExampleController]
 })
 class ExampleModule {}
@@ -60,6 +68,15 @@ describe('Discovery', () => {
   });
 
   describe('Providers', () => {
+    it('should be tolerant of potentially null providers', async () => {
+      const providers = await discoveryService.providers(
+        withMetaAtKey(ExampleClassSymbol)
+      );
+
+      const nullProvider = app.get<{}>(NullProviderSymbol);
+      expect(nullProvider).toBeNull();
+    });
+
     it('should discover providers based on a metadata key', async () => {
       const providers = await discoveryService.providers(
         withMetaAtKey(ExampleClassSymbol)

--- a/packages/discovery/src/tests/provider-types.spec.ts
+++ b/packages/discovery/src/tests/provider-types.spec.ts
@@ -1,4 +1,4 @@
-import { Injectable, Module, SetMetadata } from '@nestjs/common';
+import { Injectable, Module, SetMetadata, Scope } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { DiscoveryModule, DiscoveryService, withMetaAtKey } from '..';
 


### PR DESCRIPTION
Fixed issues where null providers could cause Discovery to trigger errors

fix #44