### PR TITLE
fix(rabbitmq): missing explicit dependency on nestjs-plus/common

### DIFF
--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -33,6 +33,7 @@
     "url": "https://github.com/WonderPanda/nestjs-plus/issues"
   },
   "dependencies": {
+    "@nestjs-plus/common": "^1.1.0",
     "@nestjs-plus/discovery": "^2.0.2",
     "amqplib": "^0.5.3",
     "uuid": "^3.3.2"


### PR DESCRIPTION
fix #65