### PR TITLE
fix(mocks): usage as nestjs providers

### DIFF
--- a/packages/testing/src/mocks.ts
+++ b/packages/testing/src/mocks.ts
@@ -44,6 +44,16 @@ export const createMock = <T>(
 
   const proxy = new Proxy(partial, {
     get: (obj, prop) => {
+      if (
+        prop === 'constructor' ||
+        prop === 'inspect' ||
+        prop === 'then' ||
+        (typeof prop === 'symbol' &&
+          prop.toString() === 'Symbol(util.inspect.custom)')
+      ) {
+        return undefined;
+      }
+
       if (cache.has(prop)) {
         return cache.get(prop);
       }


### PR DESCRIPTION
prevents call to problematic properties that can cause hung promises or stack overflows

fix #18