### PR TITLE
nestjs-discovery package.json update

### DIFF
--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@golevelup/nestjs-discovery",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A Badass NestJS module for querying your app's controllers, providers and handlers",
   "keywords": [
     "NestJS",
@@ -8,7 +8,7 @@
     "modules"
   ],
   "author": "Jesse Carter <jesse.r.carter@gmail.com>",
-  "homepage": "https://github.com/WonderPanda/nestjs-plus#readme",
+  "homepage": "https://github.com/golevelup/nestjs/blob/master/packages/discovery/README.md",
   "license": "MIT",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -24,15 +24,18 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/WonderPanda/nestjs-plus.git"
+    "url": "git+https://github.com/golevelup/nestjs.git"
   },
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "build:watch": "tsc --build tsconfig.build.json --watch",
     "test": "jest"
   },
+  "dependencies": {
+    "lodash": "^4.17.11"
+  },
   "bugs": {
-    "url": "https://github.com/WonderPanda/nestjs-plus/issues"
+    "url": "https://github.com/golevelup/nestjs/issues"
   },
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
When `lodash` is not dependency of the Nest based app production installed start fails as `lodash` is not found (`Cannot find module 'lodash'`)

 - add `lodash` as dependency
 - update bugs, repo & homepage urls