### PR TITLE
Add correlationId to request

### DIFF
--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -182,7 +182,7 @@ export class AmqpConnection {
   public async request<T extends {}>(
     requestOptions: RequestOptions
   ): Promise<T> {
-    const correlationId = uuid.v4();
+    const correlationId = requestOptions.correlationId || uuid.v4();
     const timeout = requestOptions.timeout || this.config.defaultRpcTimeout;
     const payload = requestOptions.payload || {};
 

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -15,6 +15,7 @@ export interface MessageOptions {
 export interface RequestOptions {
   exchange: string;
   routingKey: string;
+  correlationId?: string;
   timeout?: number;
   payload?: any;
 }


### PR DESCRIPTION
For use rpc with MassTransit (.Net Core) server I should be able to set the value of correlationId manuality. This pull request adds this feature.