### PR TITLE
feat(rabbitmq): optional direct reply-to

### DIFF
--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -1,5 +1,5 @@
-import * as amqplib from 'amqplib';
 import * as amqpConnectionManager from 'amqp-connection-manager';
+import * as amqplib from 'amqplib';
 
 export interface RabbitMQExchangeConfig {
   name: string;
@@ -64,6 +64,7 @@ export interface RabbitMQConfig {
   connectionInitOptions?: ConnectionInitOptions;
   connectionManagerOptions?: amqpConnectionManager.AmqpConnectionManagerOptions;
   registerHandlers?: boolean;
+  enableDirectReplyTo?: boolean;
 }
 
 export type RabbitHandlerType = 'rpc' | 'subscribe';

--- a/packages/rabbitmq/src/rabbitmq.module.ts
+++ b/packages/rabbitmq/src/rabbitmq.module.ts
@@ -120,12 +120,22 @@ export class RabbitMQModule
 
           const { exchange, routingKey, queue } = config;
 
-          this.logger.log(
-            `${discoveredMethod.parentClass.name}.${
-              discoveredMethod.methodName
-            } {${config.type}} -> ${exchange}::${routingKey}::${queue ||
-              'amqpgen'}`
-          );
+          const handlerDisplayName = `${discoveredMethod.parentClass.name}.${
+            discoveredMethod.methodName
+          } {${config.type}} -> ${exchange}::${routingKey}::${queue ||
+            'amqpgen'}`;
+
+          if (
+            config.type === 'rpc' &&
+            !this.amqpConnection.configuration.enableDirectReplyTo
+          ) {
+            this.logger.warn(
+              `Direct Reply-To Functionality is disabled. RPC handler ${handlerDisplayName} will not be registered`
+            );
+            return;
+          }
+
+          this.logger.log(handlerDisplayName);
 
           return config.type === 'rpc'
             ? this.amqpConnection.createRpc(handler, config)


### PR DESCRIPTION
Added configuration option to disable initialization of direct reply to functionality. When disabled, this will prevent the registration of any handlers that have been decorated with `@RabbitRPC` as RPC functionality currently depends on the direct reply-to