### PR TITLE
fix(common): expose full gql request api

### DIFF
--- a/packages/graphql-request/package.json
+++ b/packages/graphql-request/package.json
@@ -38,6 +38,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@golevelup/nestjs-common": "^1.4.0",
     "@golevelup/nestjs-discovery": "^2.3.0",
     "@golevelup/nestjs-modules": "^0.4.0",
     "graphql-request": "^1.8.2"

--- a/packages/graphql-request/src/graphql-request.decorators.ts
+++ b/packages/graphql-request/src/graphql-request.decorators.ts
@@ -1,0 +1,17 @@
+import { makeInjectableDecorator } from '@golevelup/nestjs-common';
+import {
+  GraphQLClientConfigInject,
+  GraphQLClientInject,
+} from './graphql-request.constants';
+
+/**
+ * Injects the GraphQL client configuration from this module into a service/controller
+ */
+export const InjectGraphQLConfig = makeInjectableDecorator(
+  GraphQLClientConfigInject
+);
+
+/**
+ * Injects the GraphQL client provided by this module into a service/controller
+ */
+export const InjectGraphQLClient = makeInjectableDecorator(GraphQLClientInject);

--- a/packages/graphql-request/src/index.ts
+++ b/packages/graphql-request/src/index.ts
@@ -1,1 +1,3 @@
+export * from './graphql-request.constants';
+export * from './graphql-request.decorators';
 export * from './graphql-request.module';


### PR DESCRIPTION
ensures that constants and decorators from graphql-request library are exposed to consumers

fix #122