### PR TITLE
feat(rabbitmq): error behaviour for replying error

### DIFF
--- a/integration/rabbitmq/src/rpc/reply.error.callback.ts
+++ b/integration/rabbitmq/src/rpc/reply.error.callback.ts
@@ -1,0 +1,20 @@
+import * as amqplib from 'amqplib';
+
+export function ReplyErrorCallback(
+  channel: amqplib.Channel,
+  msg: amqplib.ConsumeMessage,
+  error: any,
+) {
+  const { replyTo, correlationId } = msg.properties;
+  if (replyTo) {
+    if (error instanceof Error) {
+      error = error.message;
+    } else if (typeof error !== 'string') {
+      error = JSON.stringify(error);
+    }
+
+    error = Buffer.from(JSON.stringify({ status: 'error', message: error }));
+
+    channel.publish('', replyTo, error, { correlationId });
+  }
+}

--- a/integration/rabbitmq/src/rpc/rpc.service.ts
+++ b/integration/rabbitmq/src/rpc/rpc.service.ts
@@ -5,6 +5,7 @@ import {
 import { Injectable, UseInterceptors } from '@nestjs/common';
 import { TransformInterceptor } from '../transform.interceptor';
 import { RpcException } from '@nestjs/microservices';
+import { ReplyErrorCallback } from './reply.error.callback';
 
 @Injectable()
 export class RpcService {
@@ -35,7 +36,8 @@ export class RpcService {
     routingKey: 'error-reply-rpc',
     exchange: 'exchange1',
     queue: 'error-reply-rpc',
-    errorBehavior: MessageHandlerErrorBehavior.REPLYERRORANDACK,
+    errorBehavior: MessageHandlerErrorBehavior.ACK,
+    errorCallbacks: [ReplyErrorCallback],
   })
   errorReplyRpc(message: object) {
     throw new RpcException(message);

--- a/integration/rabbitmq/src/rpc/rpc.service.ts
+++ b/integration/rabbitmq/src/rpc/rpc.service.ts
@@ -1,6 +1,10 @@
-import { RabbitRPC } from '@golevelup/nestjs-rabbitmq';
+import {
+  RabbitRPC,
+  MessageHandlerErrorBehavior,
+} from '@golevelup/nestjs-rabbitmq';
 import { Injectable, UseInterceptors } from '@nestjs/common';
 import { TransformInterceptor } from '../transform.interceptor';
+import { RpcException } from '@nestjs/microservices';
 
 @Injectable()
 export class RpcService {
@@ -24,6 +28,28 @@ export class RpcService {
   interceptedRpc() {
     return {
       message: 42,
+    };
+  }
+
+  @RabbitRPC({
+    routingKey: 'error-reply-rpc',
+    exchange: 'exchange1',
+    queue: 'error-reply-rpc',
+    errorBehavior: MessageHandlerErrorBehavior.REPLYERRORANDACK,
+  })
+  errorReplyRpc(message: object) {
+    throw new RpcException(message);
+  }
+
+  @RabbitRPC({
+    routingKey: 'non-json-rpc',
+    exchange: 'exchange1',
+    queue: 'non-json-rpc',
+    allowNonJsonMessages: true,
+  })
+  nonJsonRpc(nonJsonMessage: any) {
+    return {
+      echo: nonJsonMessage,
     };
   }
 }

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -36,7 +36,13 @@ export interface QueueOptions {
 export enum MessageHandlerErrorBehavior {
   ACK,
   NACK,
-  REQUEUE
+  REQUEUE,
+  /**
+   * If an exception occurs while handling the message, the error will be serialized and published on the `replyTo` queue.
+   * If `replyTo` is not provided, the message will be NACKed without requeueing.
+   * If publish fails, message will be NACKed and requeued.
+   */
+  REPLYERRORANDACK,
 }
 
 export interface MessageHandlerOptions {

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -51,6 +51,7 @@ export interface MessageHandlerOptions {
   queue?: string;
   queueOptions?: QueueOptions;
   errorBehavior?: MessageHandlerErrorBehavior;
+  allowNonJsonMessages?: boolean;
 }
 
 export interface ConnectionInitOptions {

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -37,12 +37,6 @@ export enum MessageHandlerErrorBehavior {
   ACK,
   NACK,
   REQUEUE,
-  /**
-   * If an exception occurs while handling the message, the error will be serialized and published on the `replyTo` queue.
-   * If `replyTo` is not provided, the message will be NACKed without requeueing.
-   * If publish fails, message will be NACKed and requeued.
-   */
-  REPLYERRORANDACK,
 }
 
 export interface MessageHandlerOptions {
@@ -51,8 +45,15 @@ export interface MessageHandlerOptions {
   queue?: string;
   queueOptions?: QueueOptions;
   errorBehavior?: MessageHandlerErrorBehavior;
+  errorCallbacks?: IMessageErrorCallback[];
   allowNonJsonMessages?: boolean;
 }
+
+export type IMessageErrorCallback = (
+  channel: amqplib.Channel,
+  msg: amqplib.ConsumeMessage,
+  error: any
+) => Promise<any> | any;
 
 export interface ConnectionInitOptions {
   wait?: boolean;


### PR DESCRIPTION
I need my RPC service to return me errors, in case something goes wrong. Thus, a new error behavior has been added: 
```
  /**
   * If an exception occurs while handling the message, the error will be serialized and published on the `replyTo` queue.
   * If `replyTo` is not provided, the message will be NACKed without requeueing.
   * If publish fails, message will be NACKed and requeued.
   */
  REPLYERRORANDACK,
```

If this is set, the handler will behave as it is described in the comment.

Additionaly, I added a `try/catch` on JSON message parsing, and allowed `undefined` messages to go into the service. I believe that the service should be able to determine what to do with this. As of before, there was no option to publish an empty message to the service (`JSON.parse` would throw an error). This was the push for me to create the error behavior, as the service would by default endlessly requeue the message without me knowing what is going on.