### PR TITLE
feat(hasura): enable event routing based on trigger name

### DIFF
--- a/packages/hasura/README.md
+++ b/packages/hasura/README.md
@@ -55,7 +55,29 @@ The Hasura Module supports both the `forRoot` and `forRootAsync` patterns for co
 
 ### Registering Event Handlers
 
-Decorate methods in your NestJS providers in order to have them be automatically attached as event handlers for incoming Hasura events. The event payload will be analyzed and routed to your provider methods based on the table and schema name provided in the decorator.
+Decorate methods in your NestJS providers in order to have them be automatically attached as event handlers for incoming Hasura events. The event payload will be analyzed and routed to your provider methods based on the configuration provided in the decorator.
+
+#### Route based on Hasura Trigger Name
+
+The recommended method of routing to the correct event handler is to specify the Hasura Trigger Name in the decorator. This will ensure that you have the flexibility to have multiple events targeting the same table with different operation types and column sets.
+
+```typescript
+import { HasuraEventHandler, HasuraEvent } from '@golevelup/nestjs-hasura';
+
+@Injectable()
+class UsersService {
+  @HasuraEventHandler({
+    triggerName: 'user_created',
+  })
+  handleUserCreated(evt: HasuraEvent) {
+    // handle the event payload. Typing the method parameter with `HasurEvent` will provide intellisense
+  }
+}
+```
+
+#### Route Based on Schema and Table Name (Deprecated)
+
+It is possible to configure routing to the event handler based on the schema and table name of the source event. This is deprecated and not recommended as it is a less flexible way to route events and will be removed in a future release.
 
 The schema name is optional and if not provided will default to `public`.
 

--- a/packages/hasura/src/hasura.interfaces.ts
+++ b/packages/hasura/src/hasura.interfaces.ts
@@ -32,7 +32,16 @@ export type TypedHasuraEvent<T> = Omit<HasuraEvent, 'event'> & {
 };
 
 export interface HasuraEventHandlerConfig {
-  table: { schema?: string; name: string };
+  /**
+   * @deprecated Table information for the event trigger which will will be used to route the event.
+   * It is recommended to use `triggerName` instead as multiple events can use the same table which
+   * makes routing to the correct handler more difficult
+   */
+  table?: { schema?: string; name: string };
+  /**
+   * The name of the Hasura Trigger which created this event
+   */
+  triggerName?: string;
 }
 
 export interface HasuraModuleConfig {


### PR DESCRIPTION
deprecates the old model of binding events based on the source schema and table to one that
leverages the hasura trigger name

fixes #152