### PR TITLE
fix(rabbitmq): error behavior enum

### DIFF
--- a/packages/rabbitmq/src/amqp/errorBehaviors.ts
+++ b/packages/rabbitmq/src/amqp/errorBehaviors.ts
@@ -1,9 +1,9 @@
 import * as amqplib from 'amqplib';
 
 export enum MessageHandlerErrorBehavior {
-  ACK,
-  NACK,
-  REQUEUE,
+  ACK = 'ACK',
+  NACK = 'NACK',
+  REQUEUE = 'REQUEUE',
 }
 
 export type MessageErrorHandler = (


### PR DESCRIPTION
use string enum to prevent 0 falsiness issues

fix #187