### PR TITLE
fix(ts-jest): handling falsy values and undefined

### DIFF
--- a/packages/testing/src/mocks.spec.ts
+++ b/packages/testing/src/mocks.spec.ts
@@ -5,6 +5,8 @@ import { createMock, DeepMocked } from './mocks';
 
 interface TestInterface {
   someNum: number;
+  someBool: boolean;
+  optional: string | undefined;
   func: (num: number, str: string) => boolean;
 }
 
@@ -40,6 +42,34 @@ describe('Mocks', () => {
 
       expect(result).toBe(request);
       expect(mock.switchToHttp).toBeCalledTimes(1);
+    });
+
+    it('should work with truthy values properties', () => {
+      const mock = createMock<TestInterface>({
+        someNum: 1,
+        someBool: true,
+      });
+
+      expect(mock.someNum).toBe(1);
+      expect(mock.someBool).toBe(true);
+    });
+
+    it('should work with falsy values properties', () => {
+      const mock = createMock<TestInterface>({
+        someNum: 0,
+        someBool: false,
+      });
+
+      expect(mock.someNum).toBe(0);
+      expect(mock.someBool).toBe(false);
+    });
+
+    it('should work with optional values explicitly returning undefined', () => {
+      const mock = createMock<TestInterface>({
+        optional: undefined,
+      });
+
+      expect(mock.optional).toBe(undefined);
     });
 
     it('should work with properties and functions', () => {

--- a/packages/testing/src/mocks.ts
+++ b/packages/testing/src/mocks.ts
@@ -34,13 +34,14 @@ const createRecursiveMockProxy = (name: string) => {
 
         const checkProp = obj[prop];
 
-        const mockedProp = checkProp
-          ? typeof checkProp === 'function'
-            ? jest.fn()
-            : checkProp
-          : propName === 'then'
-          ? undefined
-          : createRecursiveMockProxy(propName);
+        const mockedProp =
+          prop in obj
+            ? typeof checkProp === 'function'
+              ? jest.fn()
+              : checkProp
+            : propName === 'then'
+            ? undefined
+            : createRecursiveMockProxy(propName);
 
         cache.set(prop, mockedProp);
 
@@ -81,11 +82,12 @@ export const createMock = <T extends object>(
 
       const checkProp = obj[prop];
 
-      const mockedProp = checkProp
-        ? typeof checkProp === 'function'
-          ? jest.fn(checkProp)
-          : checkProp
-        : createRecursiveMockProxy(`${name}.${prop.toString()}`);
+      const mockedProp =
+        prop in obj
+          ? typeof checkProp === 'function'
+            ? jest.fn(checkProp)
+            : checkProp
+          : createRecursiveMockProxy(`${name}.${prop.toString()}`);
 
       cache.set(prop, mockedProp);
       return mockedProp;


### PR DESCRIPTION
check for presence of property instead of relying on whether or not it is truthy

fix #211