### PR TITLE
feat(hasura): allow for custom decorators on controller

### DIFF
--- a/packages/hasura/src/hasura.interfaces.ts
+++ b/packages/hasura/src/hasura.interfaces.ts
@@ -161,6 +161,13 @@ export interface HasuraModuleConfig {
    * to send events. Defaults to 'hasura'
    */
   controllerPrefix?: string;
+
+  /**
+   * An optional array of class decorators to apply to the `EventHandlerController`. These decorators can
+   * only apply metadata that will be read at request time, and not read at start time (i.e. you cannot use
+   * `@UseGuards()`, `@UseInterceptor()` or any other NestJS enhancer decorators)
+   */
+  decorators?: ClassDecorator[];
 }
 
 export type HasuraAction<T = Record<string, string>> = {

--- a/packages/hasura/src/hasura.module.ts
+++ b/packages/hasura/src/hasura.module.ts
@@ -61,6 +61,9 @@ export class HasuraModule
               controllerPrefix,
               EventHandlerController
             );
+            config.decorators?.forEach((deco) => {
+              deco(EventHandlerController);
+            });
           },
           inject: [HASURA_MODULE_CONFIG],
         },


### PR DESCRIPTION
With the `decorators` property, devs are able to provide some custom
decorators to apply metadata that will be read at the time of the request
which will allow a dev to have a global auth guard or interceptor and
allow the guard or interceptor to be skipped, or ran differently on the
controller managed by the hasura package