### PR TITLE
docs: propose to use a function for deferred

### DIFF
--- a/packages/modules/README.md
+++ b/packages/modules/README.md
@@ -109,7 +109,7 @@ export class ConfigModule extends createConfigurableDynamicRootModule<
   ConfigModule,
   ConfigModuleOptions
 >(CONFIG_MODULE_OPTIONS) {
-  static Deferred = ConfigModule.externallyConfigured(ConfigModule, 0);
+  static deferred = () => ConfigModule.externallyConfigured(ConfigModule, 0);
 }
 ```
 
@@ -117,7 +117,7 @@ Now it can be used in another module like this:
 
 ```ts
 @Module({
-  imports: [ConfigModule.Deferred],
+  imports: [ConfigModule.deferred()],
 })
 export class ConfigModuleDependentModule {}
 ```


### PR DESCRIPTION
When using deferred as a static prop, problems will arise in setups where you reuse across multiple apps from a configurable core module, since externallyConfigured is called without the module actually being imported by another module.