### PR TITLE
fix(rabbitmq): prevent unhandled promise rejection warning

### DIFF
--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -214,7 +214,7 @@ export class AmqpConnection {
     } catch (error) {
       //Catching errors from the publish function to prevent UnhandledPromiseRejectionWarning
       //Rethrow error so the caller of this function can catch the error.
-      throw e;
+      throw new Error(error.message);
     }
 
     const timeout$ = interval(timeout).pipe(

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -22,7 +22,6 @@ import {
   MessageHandlerErrorBehavior,
 } from './errorBehaviors';
 import { Nack, RpcResponse, SubscribeResponse } from './handlerResponses';
-import e = require('express');
 
 const DIRECT_REPLY_QUEUE = 'amq.rabbitmq.reply-to';
 

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -201,21 +201,16 @@ export class AmqpConnection {
       map((x) => x.message as T),
       first()
     );
-    try {
-      await this.publish(
-        requestOptions.exchange,
-        requestOptions.routingKey,
-        payload,
-        {
-          replyTo: DIRECT_REPLY_QUEUE,
-          correlationId,
-        }
-      );
-    } catch (error) {
-      //Catching errors from the publish function to prevent UnhandledPromiseRejectionWarning
-      //Rethrow error so the caller of this function can catch the error.
-      throw new Error(error.message);
-    }
+
+    await this.publish(
+      requestOptions.exchange,
+      requestOptions.routingKey,
+      payload,
+      {
+        replyTo: DIRECT_REPLY_QUEUE,
+        correlationId,
+      }
+    );
 
     const timeout$ = interval(timeout).pipe(
       first(),


### PR DESCRIPTION
Catch and rethrow errors from the publish function to prevent UnhandledPromiseRejectionWarning

fix #259