### PR TITLE
feat(stripe): add ability to use custom decorators on controller

### DIFF
--- a/packages/stripe/README.md
+++ b/packages/stripe/README.md
@@ -107,7 +107,7 @@ Failure to give Stripe access to the raw body will result in nasty runtime error
 
 ### Decorate Methods For Processing Webhook Events
 
-Exposing provider/service methods to be used for processing Stripe events is easy! Simply use the provided decorator and indiciate the event type that the handler should receive.
+Exposing provider/service methods to be used for processing Stripe events is easy! Simply use the provided decorator and indicate the event type that the handler should receive.
 
 [Review the Stripe documentation](https://stripe.com/docs/api/events/types) for more information about the types of events available.
 
@@ -121,6 +121,20 @@ class PaymentCreatedService {
 }
 ```
 
+### Webhook Controller Decorators
+
+You can also pass any class decorator to the `decorators` property of the `webhookConfig` object as a part of the module configuration. This could be used in situations like when using the `@nestjs/throttler` package and needing to apply the `@ThrottlerSkip()` decorator, or when you have a global guard but need to skip routes with certain metadata.
+
+````typescript
+StripeModule.forRoot(StripeModule, {
+  apiKey: '123',
+  webhookConfig: {
+    stripeWebhookSecret: 'super-secret',
+    decorators: [ThrottlerSkip()],
+  },
+}),
+```
+
 ### Configure Webhooks in the Stripe Dashboard
 
 Follow the instructions from the [Stripe Documentation](https://stripe.com/docs/webhooks) for remaining integration steps such as testing your integration with the CLI before you go live and properly configuring the endpoint from the Stripe dashboard so that the correct events are sent to your NestJS app.
@@ -132,3 +146,4 @@ Contributions welcome! Read the [contribution guidelines](../../CONTRIBUTING.md)
 ## License
 
 [MIT License](../../LICENSE)
+````

--- a/packages/stripe/src/stripe.interfaces.ts
+++ b/packages/stripe/src/stripe.interfaces.ts
@@ -23,6 +23,13 @@ export interface StripeModuleConfig extends Partial<Stripe.StripeConfig> {
     controllerPrefix?: string;
 
     /**
+     * Any metadata specific decorators you want to apply to the webhook handling controller.
+     *
+     * Note: these decorators must only set metadata that will be read at request time. Decorators like Nest's `@UsePipes()` or `@UseInterceptors()` wll not work, due to the time at which Nest reads the metadata for those, but something  that uses `SetMetadata` will be fine, because that metadata is read at request time.
+     */
+    decorators?: ClassDecorator[];
+
+    /**
      * Logging configuration
      */
     loggingConfiguration?: {

--- a/packages/stripe/src/stripe.module.ts
+++ b/packages/stripe/src/stripe.module.ts
@@ -37,6 +37,9 @@ export class StripeModule
               controllerPrefix,
               StripeWebhookController
             );
+            config.webhookConfig?.decorators?.forEach((deco) => {
+              deco(StripeWebhookController);
+            });
           },
           inject: [STRIPE_MODULE_CONFIG_TOKEN],
         },


### PR DESCRIPTION
This is a new feature to allow for custom decorators to be called on the `StripeWebhookController` that is managed by the `StripeModule`. Tests, and docs are added