### PR TITLE
feat(rabbitmq): log the disconnect event from connection manager

### DIFF
--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -124,6 +124,10 @@ export class AmqpConnection {
       this.logger.log('Successfully connected to a RabbitMQ broker');
     });
 
+    this._managedConnection.on('disconnect', ({ err }) => {
+      this.logger.error('Disconnected from RabbitMQ broker', err?.stack);
+    });
+
     this._managedChannel = this._managedConnection.createChannel({
       name: AmqpConnection.name,
     });


### PR DESCRIPTION
When the node-amqp-connection-manager disconnects it emits an event. This event is now ignored and
therefore it is not visisble what the disconnect reason is. This is usefull information