### PR TITLE
#316: Make exchange and routing key optional

### DIFF
--- a/integration/rabbitmq/e2e/subscribe.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/subscribe.e2e-spec.ts
@@ -188,42 +188,35 @@ describe('Rabbit Subscribe', () => {
 
   it('should receive messages in existing queue without setting exchange and routing key on subscribe', async (done) => {
     // publish to the default exchange, using the queue as routing key
-    amqpConnection.publish(
-      amqDefaultExchange,
-      preExistingQueue,
-      '{"key":"value 1"}',
-    );
-    amqpConnection.publish(
-      amqDefaultExchange,
-      preExistingQueue,
-      '{"key":"value 2"}',
-    );
-    amqpConnection.publish(
-      amqDefaultExchange,
-      preExistingQueue,
-      '{"key":"value 3"}',
-    );
+    const message1 = '{"key":"value 1"}';
+    const message2 = '{"key":"value 2"}';
+    const message3 = '{"key":"value 3"}';
+
+    amqpConnection.publish(amqDefaultExchange, preExistingQueue, message1);
+    amqpConnection.publish(amqDefaultExchange, preExistingQueue, message2);
+    amqpConnection.publish(amqDefaultExchange, preExistingQueue, message3);
 
     // ASSERT
-    expect.assertions(1);
+    expect.assertions(4);
     setTimeout(() => {
       expect(testHandler).toHaveBeenCalledTimes(3);
+      expect(testHandler).toHaveBeenCalledWith(message1);
+      expect(testHandler).toHaveBeenCalledWith(message2);
+      expect(testHandler).toHaveBeenCalledWith(message3);
       done();
     }, 50);
   });
 
   it('should receive messages in new queue without setting exchange routing key on subscribe', async (done) => {
+    const message = '{"key":"value"}';
     // publish to the default exchange, using the queue as routing key
-    amqpConnection.publish(
-      amqDefaultExchange,
-      nonExistingQueue,
-      '{"key":"value"}',
-    );
+    amqpConnection.publish(amqDefaultExchange, nonExistingQueue, message);
 
     // ASSERT
-    expect.assertions(1);
+    expect.assertions(2);
     setTimeout(() => {
       expect(testHandler).toHaveBeenCalledTimes(1);
+      expect(testHandler).toHaveBeenCalledWith(message);
       done();
     }, 50);
   });

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -417,7 +417,8 @@ export class AmqpConnection {
       routingKey,
       createQueueIfNotExists = true,
     } = subscriptionOptions;
-    let actualQueue: unknown;
+
+    let actualQueue: string;
 
     if (createQueueIfNotExists) {
       const { queue } = await channel.assertQueue(
@@ -444,6 +445,6 @@ export class AmqpConnection {
       );
     }
 
-    return actualQueue as string;
+    return actualQueue;
   }
 }

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -38,8 +38,8 @@ export interface QueueOptions {
 }
 
 export interface MessageHandlerOptions {
-  exchange: string;
-  routingKey: string | string[];
+  exchange?: string;
+  routingKey?: string | string[];
   queue?: string;
   queueOptions?: QueueOptions;
   /**

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -52,7 +52,7 @@ export interface MessageHandlerOptions {
    */
   errorHandler?: MessageErrorHandler;
   allowNonJsonMessages?: boolean;
-  createQueueWhenNotExisting?: boolean;
+  createQueueIfNotExists?: boolean;
 }
 
 export interface ConnectionInitOptions {

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -52,6 +52,7 @@ export interface MessageHandlerOptions {
    */
   errorHandler?: MessageErrorHandler;
   allowNonJsonMessages?: boolean;
+  createQueueWhenNotExisting?: boolean;
 }
 
 export interface ConnectionInitOptions {


### PR DESCRIPTION
I tried to prepare a PR for the topics discussed in #316 . I encountered an additional error when I was working with queues that already existed on the server, so I thought it would be a good idea to dynamically switch between `assertQueue` and `checkQueue`.

- Introduce additional option to assert or check queue
- Only bind queues, if exchange **and** routing key(s) is provided

Please help me improve this. I was not able to run the tests, they just failed with "cannot find module @golevelup/nestjs-common". Probably did something wrong setting up the sub-project.