### PR TITLE
docs: include `add` in installation instruction

### DIFF
--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -33,7 +33,7 @@ npm i @golevelup/ts-jest
 or
 
 ```sh
-yarn @golevelup/ts-jest
+yarn add @golevelup/ts-jest
 ```
 
 ### Creating Mocks


### PR DESCRIPTION
Include missing `add` in yarn installation instruction