### PR TITLE
feat: add option for arguments when binding queue to an exchange

### DIFF
--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -433,13 +433,23 @@ export class AmqpConnection {
       actualQueue = queue;
     }
 
+    let bindQueueArguments: any;
+    if (subscriptionOptions.queueOptions) {
+      bindQueueArguments = subscriptionOptions.queueOptions.bindQueueArguments;
+    }
+
     const routingKeys = Array.isArray(routingKey) ? routingKey : [routingKey];
 
     if (exchange && routingKeys) {
       await Promise.all(
         routingKeys.map((routingKey) => {
           if (routingKey != null) {
-            channel.bindQueue(actualQueue as string, exchange, routingKey);
+            channel.bindQueue(
+              actualQueue as string,
+              exchange,
+              routingKey,
+              bindQueueArguments
+            );
           }
         })
       );

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -35,6 +35,7 @@ export interface QueueOptions {
   deadLetterRoutingKey?: string;
   maxLength?: number;
   maxPriority?: number;
+  bindQueueArguments?: any;
 }
 
 export interface MessageHandlerOptions {


### PR DESCRIPTION
currently, there is no option to pass args to the channel.bindQueue function.  Passing arguments to
this function is required for some exchange types and queue-exchange setups

re #343 