### PR TITLE
use context type rmq instead of http

### DIFF
--- a/packages/rabbitmq/src/rabbitmq.module.ts
+++ b/packages/rabbitmq/src/rabbitmq.module.ts
@@ -127,7 +127,13 @@ export class RabbitMQModule
           const handler = this.externalContextCreator.create(
             discoveredMethod.parentClass.instance,
             discoveredMethod.handler,
-            discoveredMethod.methodName
+            discoveredMethod.methodName,
+            undefined, 
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            'rmq'
           );
 
           const { exchange, routingKey, queue } = config;


### PR DESCRIPTION
if you use global nestjs exception handler or interceptor, rmq request context marked as an HTTP request but it's not, people try to handle rmq requests with HTTP methods and gets null pointer exception.