### PR TITLE
fix: fixed breaking change in rabbitmq package

### DIFF
--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -64,7 +64,7 @@ export interface MessageHandlerOptions {
   /**
    * A function that will be called if an error is thown during queue creation (i.e during channel.assertQueue)
    */
-  assertQueueErrorHandler: AssertQueueErrorHandler;
+  assertQueueErrorHandler?: AssertQueueErrorHandler;
   allowNonJsonMessages?: boolean;
   createQueueIfNotExists?: boolean;
 }


### PR DESCRIPTION
The non optional field assertQueueErrorHandler in the MessageHandlerOptions interface broke existing
code. This has been fixed.

fix #364