### PR TITLE
feat: RabbitMQ 3rd party imports improvement 

### DIFF
--- a/packages/rabbitmq/src/amqp/errorBehaviors.ts
+++ b/packages/rabbitmq/src/amqp/errorBehaviors.ts
@@ -1,4 +1,4 @@
-import * as amqplib from 'amqplib';
+import { Channel, ConsumeMessage } from 'amqplib';
 import { QueueOptions } from '../rabbitmq.interfaces';
 
 export enum MessageHandlerErrorBehavior {
@@ -8,37 +8,29 @@ export enum MessageHandlerErrorBehavior {
 }
 
 export type MessageErrorHandler = (
-  channel: amqplib.Channel,
-  msg: amqplib.ConsumeMessage,
+  channel: Channel,
+  msg: ConsumeMessage,
   error: any
 ) => Promise<void> | void;
 
 /**
  * An error handler that will ack the message which caused an error during processing
  */
-export const ackErrorHandler: MessageErrorHandler = (channel, msg, error) => {
+export const ackErrorHandler: MessageErrorHandler = (channel, msg) => {
   channel.ack(msg);
 };
 
 /**
  * An error handler that will nack and requeue a message which created an error during processing
  */
-export const requeueErrorHandler: MessageErrorHandler = (
-  channel,
-  msg,
-  error
-) => {
+export const requeueErrorHandler: MessageErrorHandler = (channel, msg) => {
   channel.nack(msg, false, true);
 };
 
 /**
  * An error handler that will nack a message which created an error during processing
  */
-export const defaultNackErrorHandler: MessageErrorHandler = (
-  channel,
-  msg,
-  error
-) => {
+export const defaultNackErrorHandler: MessageErrorHandler = (channel, msg) => {
   channel.nack(msg, false, false);
 };
 
@@ -56,7 +48,7 @@ export const getHandlerForLegacyBehavior = (
 };
 
 export type AssertQueueErrorHandler = (
-  channel: amqplib.Channel,
+  channel: Channel,
   queueName: string,
   queueOptions: QueueOptions | undefined,
   error: any
@@ -66,7 +58,7 @@ export type AssertQueueErrorHandler = (
  * Just rethrows the error
  */
 export const defaultAssertQueueErrorHandler: AssertQueueErrorHandler = (
-  channel: amqplib.Channel,
+  channel: Channel,
   queueName: string,
   queueOptions: QueueOptions | undefined,
   error: any
@@ -78,7 +70,7 @@ export const defaultAssertQueueErrorHandler: AssertQueueErrorHandler = (
  * Tries to delete the queue and to redeclare it with the provided options
  */
 export const forceDeleteAssertQueueErrorHandler: AssertQueueErrorHandler = async (
-  channel: amqplib.Channel,
+  channel: Channel,
   queueName: string,
   queueOptions: QueueOptions | undefined,
   error: any

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -1,5 +1,5 @@
-import * as amqpConnectionManager from 'amqp-connection-manager';
-import * as amqplib from 'amqplib';
+import { AmqpConnectionManagerOptions } from 'amqp-connection-manager';
+import { Options } from 'amqplib';
 import {
   AssertQueueErrorHandler,
   MessageErrorHandler,
@@ -9,7 +9,7 @@ import {
 export interface RabbitMQExchangeConfig {
   name: string;
   type?: string;
-  options?: amqplib.Options.AssertExchange;
+  options?: Options.AssertExchange;
 }
 
 export interface MessageOptions {
@@ -75,6 +75,8 @@ export interface ConnectionInitOptions {
   reject?: boolean;
 }
 
+export type RabbitMQChannels = Record<string, RabbitMQChannelConfig>;
+
 export interface RabbitMQConfig {
   uri: string | string[];
   /**
@@ -87,7 +89,7 @@ export interface RabbitMQConfig {
   defaultRpcErrorBehavior?: MessageHandlerErrorBehavior;
   defaultSubscribeErrorBehavior?: MessageHandlerErrorBehavior;
   connectionInitOptions?: ConnectionInitOptions;
-  connectionManagerOptions?: amqpConnectionManager.AmqpConnectionManagerOptions;
+  connectionManagerOptions?: AmqpConnectionManagerOptions;
   registerHandlers?: boolean;
   enableDirectReplyTo?: boolean;
   /**
@@ -95,7 +97,7 @@ export interface RabbitMQConfig {
    *
    * By setting `prefetchCount` for a channel, you can manage message speeds of your various handlers on the same connection.
    */
-  channels?: Record<string, RabbitMQChannelConfig>;
+  channels?: RabbitMQChannels;
 }
 
 export type RabbitHandlerType = 'rpc' | 'subscribe';


### PR DESCRIPTION
This PR will make sure only specific types are imported directly from `amqp-connection-manager` and `amqplib` so that its not necessary to install `@types/amqplib`
