### PR TITLE
feat: RabbitMQ message expiration property

### DIFF
--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -264,6 +264,7 @@ export class AmqpConnection {
         replyTo: DIRECT_REPLY_QUEUE,
         correlationId,
         headers: requestOptions.headers,
+        expiration: requestOptions.expiration,
       }
     );
 
@@ -385,9 +386,13 @@ export class AmqpConnection {
           return;
         }
 
-        const { replyTo, correlationId, headers } = msg.properties;
+        const { replyTo, correlationId, expiration, headers } = msg.properties;
         if (replyTo) {
-          await this.publish('', replyTo, response, { correlationId, headers });
+          await this.publish('', replyTo, response, {
+            correlationId,
+            expiration,
+            headers,
+          });
         }
         channel.ack(msg);
       } catch (e) {

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -24,6 +24,7 @@ export interface RequestOptions {
   timeout?: number;
   payload?: any;
   headers?: any;
+  expiration?: string | number;
 }
 
 export interface QueueOptions {


### PR DESCRIPTION
Allows the usage of `expiration` properties while publishing a message
This addresses the issue with #270 