### PR TITLE
Add `all-contributors`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,286 @@
+{
+  "projectName": "nestjs",
+  "projectOwner": "golevelup",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "commitConvention": "angular",
+  "contributors": [
+    {
+      "login": "WonderPanda",
+      "name": "Jesse Carter",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3631771?v=4",
+      "profile": "https://github.com/WonderPanda",
+      "contributions": [
+        "code",
+        "ideas"
+      ]
+    },
+    {
+      "login": "azuker",
+      "name": "Amir Zuker",
+      "avatar_url": "https://avatars.githubusercontent.com/u/16463911?v=4",
+      "profile": "https://github.com/azuker",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "jmcdo29",
+      "name": "Jay McDoniel",
+      "avatar_url": "https://avatars.githubusercontent.com/u/28268680?v=4",
+      "profile": "https://github.com/jmcdo29",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "underfisk",
+      "name": "Rodrigo",
+      "avatar_url": "https://avatars.githubusercontent.com/u/15980884?v=4",
+      "profile": "https://github.com/underfisk",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "arjenvdhave",
+      "name": "Arjen van der Have",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4239126?v=4",
+      "profile": "https://github.com/arjenvdhave",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "IamBlueSlime",
+      "name": "Jérémy Levilain",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6763873?v=4",
+      "profile": "https://jeremylvln.fr/",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "perf2711",
+      "name": "Sebastian Alex",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9085864?v=4",
+      "profile": "https://github.com/perf2711",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "neilime",
+      "name": "Emilien Escalle",
+      "avatar_url": "https://avatars.githubusercontent.com/u/314088?v=4",
+      "profile": "https://www.escemi.com/",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "n3n",
+      "name": "Nonpawit Teerachetmongkol",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5567955?v=4",
+      "profile": "https://github.com/n3n",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "danocmx",
+      "name": "GlenCoco",
+      "avatar_url": "https://avatars.githubusercontent.com/u/43742709?v=4",
+      "profile": "https://github.com/danocmx",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "aaabramov",
+      "name": "Andrii Abramov",
+      "avatar_url": "https://avatars.githubusercontent.com/u/11317222?v=4",
+      "profile": "https://stackoverflow.com/users/5091346/andrii-abramov",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "ABZ0",
+      "name": "Abdallah Hemedah",
+      "avatar_url": "https://avatars.githubusercontent.com/u/38118193?v=4",
+      "profile": "https://github.com/ABZ0",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "vaidashi",
+      "name": "Ashish Vaid",
+      "avatar_url": "https://avatars.githubusercontent.com/u/25907721?v=4",
+      "profile": "https://github.com/vaidashi",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "bbangert",
+      "name": "Ben Bangert",
+      "avatar_url": "https://avatars.githubusercontent.com/u/100193?v=4",
+      "profile": "http://be.groovie.org/",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "ChrisBates",
+      "name": "ChrisBates",
+      "avatar_url": "https://avatars.githubusercontent.com/u/50668839?v=4",
+      "profile": "https://github.com/ChrisBates",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "GavinRay97",
+      "name": "Gavin Ray",
+      "avatar_url": "https://avatars.githubusercontent.com/u/26604994?v=4",
+      "profile": "https://github.com/GavinRay97",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "jlally21",
+      "name": "Joseph Lally",
+      "avatar_url": "https://avatars.githubusercontent.com/u/17992893?v=4",
+      "profile": "https://github.com/jlally21",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "robertpallas",
+      "name": "Robert Pallas",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1502325?v=4",
+      "profile": "https://github.com/robertpallas",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "priyashpatil",
+      "name": "Priyash Patil",
+      "avatar_url": "https://avatars.githubusercontent.com/u/38959321?v=4",
+      "profile": "https://priyashpatil.com/",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "tomjdickson",
+      "name": "Tom Dickson",
+      "avatar_url": "https://avatars.githubusercontent.com/u/44155439?v=4",
+      "profile": "https://github.com/tomjdickson",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "timoklingenhoefer",
+      "name": "timoklingenhoefer",
+      "avatar_url": "https://avatars.githubusercontent.com/u/39903601?v=4",
+      "profile": "https://github.com/timoklingenhoefer",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "steinroe",
+      "name": "Philipp",
+      "avatar_url": "https://avatars.githubusercontent.com/u/19429600?v=4",
+      "profile": "https://github.com/steinroe",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "zarv1k",
+      "name": "Dmitry Zarva",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6296643?v=4",
+      "profile": "https://github.com/zarv1k",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "nosyminotaur",
+      "name": "Harsh Pathak",
+      "avatar_url": "https://avatars.githubusercontent.com/u/41340243?v=4",
+      "profile": "https://github.com/nosyminotaur",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "j-schreiber",
+      "name": "Jannis Schreiber",
+      "avatar_url": "https://avatars.githubusercontent.com/u/27278807?v=4",
+      "profile": "https://lietzau-consulting.de/",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "nelsonBlack",
+      "name": "Nelson Bwogora",
+      "avatar_url": "https://avatars.githubusercontent.com/u/13407936?v=4",
+      "profile": "https://www.linkedin.com/in/nelson-bwogora-b0965713/",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "zerobig",
+      "name": "zerobig",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3147314?v=4",
+      "profile": "https://github.com/zerobig",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "sudo-kaizen",
+      "name": "Orim Dominic Adah",
+      "avatar_url": "https://avatars.githubusercontent.com/u/37955249?v=4",
+      "profile": "https://sudocodes.vercel.app/",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "angristan",
+      "name": "Stanislas",
+      "avatar_url": "https://avatars.githubusercontent.com/u/11699655?v=4",
+      "profile": "https://stanislas.blog/",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "bugsduggan",
+      "name": "Tom Lakesman",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1367638?v=4",
+      "profile": "http://tom.lakesman.co.uk/",
+      "contributions": [
+        "code"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7
+}

--- a/README.md
+++ b/README.md
@@ -27,3 +27,60 @@ Contributions welcome! Read the [contribution guidelines](CONTRIBUTING.md) first
 ## License
 
 [MIT License](LICENSE)
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://github.com/WonderPanda"><img src="https://avatars.githubusercontent.com/u/3631771?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jesse Carter</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=WonderPanda" title="Code">💻</a> <a href="#ideas-WonderPanda" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/azuker"><img src="https://avatars.githubusercontent.com/u/16463911?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Amir Zuker</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=azuker" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/jmcdo29"><img src="https://avatars.githubusercontent.com/u/28268680?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jay McDoniel</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=jmcdo29" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/underfisk"><img src="https://avatars.githubusercontent.com/u/15980884?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Rodrigo</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=underfisk" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/arjenvdhave"><img src="https://avatars.githubusercontent.com/u/4239126?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Arjen van der Have</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=arjenvdhave" title="Code">💻</a></td>
+    <td align="center"><a href="https://jeremylvln.fr/"><img src="https://avatars.githubusercontent.com/u/6763873?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jérémy Levilain</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=IamBlueSlime" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/perf2711"><img src="https://avatars.githubusercontent.com/u/9085864?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sebastian Alex</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=perf2711" title="Code">💻</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://www.escemi.com/"><img src="https://avatars.githubusercontent.com/u/314088?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Emilien Escalle</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=neilime" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/n3n"><img src="https://avatars.githubusercontent.com/u/5567955?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Nonpawit Teerachetmongkol</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=n3n" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/danocmx"><img src="https://avatars.githubusercontent.com/u/43742709?v=4?s=100" width="100px;" alt=""/><br /><sub><b>GlenCoco</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=danocmx" title="Code">💻</a></td>
+    <td align="center"><a href="https://stackoverflow.com/users/5091346/andrii-abramov"><img src="https://avatars.githubusercontent.com/u/11317222?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Andrii Abramov</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=aaabramov" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/ABZ0"><img src="https://avatars.githubusercontent.com/u/38118193?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Abdallah Hemedah</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=ABZ0" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/vaidashi"><img src="https://avatars.githubusercontent.com/u/25907721?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ashish Vaid</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=vaidashi" title="Code">💻</a></td>
+    <td align="center"><a href="http://be.groovie.org/"><img src="https://avatars.githubusercontent.com/u/100193?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ben Bangert</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=bbangert" title="Code">💻</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/ChrisBates"><img src="https://avatars.githubusercontent.com/u/50668839?v=4?s=100" width="100px;" alt=""/><br /><sub><b>ChrisBates</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=ChrisBates" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/GavinRay97"><img src="https://avatars.githubusercontent.com/u/26604994?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Gavin Ray</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=GavinRay97" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/jlally21"><img src="https://avatars.githubusercontent.com/u/17992893?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Joseph Lally</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=jlally21" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/robertpallas"><img src="https://avatars.githubusercontent.com/u/1502325?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Robert Pallas</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=robertpallas" title="Code">💻</a></td>
+    <td align="center"><a href="https://priyashpatil.com/"><img src="https://avatars.githubusercontent.com/u/38959321?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Priyash Patil</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=priyashpatil" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/tomjdickson"><img src="https://avatars.githubusercontent.com/u/44155439?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Tom Dickson</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=tomjdickson" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/timoklingenhoefer"><img src="https://avatars.githubusercontent.com/u/39903601?v=4?s=100" width="100px;" alt=""/><br /><sub><b>timoklingenhoefer</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=timoklingenhoefer" title="Code">💻</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/steinroe"><img src="https://avatars.githubusercontent.com/u/19429600?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Philipp</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=steinroe" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/zarv1k"><img src="https://avatars.githubusercontent.com/u/6296643?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Dmitry Zarva</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=zarv1k" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/nosyminotaur"><img src="https://avatars.githubusercontent.com/u/41340243?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Harsh Pathak</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=nosyminotaur" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://lietzau-consulting.de/"><img src="https://avatars.githubusercontent.com/u/27278807?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jannis Schreiber</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=j-schreiber" title="Code">💻</a></td>
+    <td align="center"><a href="https://www.linkedin.com/in/nelson-bwogora-b0965713/"><img src="https://avatars.githubusercontent.com/u/13407936?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Nelson Bwogora</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=nelsonBlack" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/zerobig"><img src="https://avatars.githubusercontent.com/u/3147314?v=4?s=100" width="100px;" alt=""/><br /><sub><b>zerobig</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=zerobig" title="Code">💻</a></td>
+    <td align="center"><a href="https://sudocodes.vercel.app/"><img src="https://avatars.githubusercontent.com/u/37955249?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Orim Dominic Adah</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=sudo-kaizen" title="Documentation">📖</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://stanislas.blog/"><img src="https://avatars.githubusercontent.com/u/11699655?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stanislas</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=angristan" title="Documentation">📖</a></td>
+    <td align="center"><a href="http://tom.lakesman.co.uk/"><img src="https://avatars.githubusercontent.com/u/1367638?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Tom Lakesman</b></sub></a><br /><a href="https://github.com/golevelup/nestjs/commits?author=bugsduggan" title="Code">💻</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!


### PR DESCRIPTION
This PR enroll this repository in `all-contributors`, which is a bot to list all the contributors of a project to the README (which looks really cool btw). I've look for all the previous commits to list the scopes properly for everyone.

Note that you may want to install the GitHub bot too: https://allcontributors.org/