### PR TITLE
chore: replace shortid with nanoid

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -33,10 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "shortid": "^2.2.14"
-  },
-  "devDependencies": {
-    "@types/shortid": "^0.0.29"
+    "nanoid": "^3.2.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/packages/common/src/mixins.ts
+++ b/packages/common/src/mixins.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { generate } from 'shortid';
+import { nanoid } from 'nanoid';
 
-export const makeInjectableMixin = (name: string) => mixinClass => {
+export const makeInjectableMixin = (name: string) => (mixinClass) => {
   Object.defineProperty(mixinClass, 'name', {
-    value: `${name}-${generate()}`
+    value: `${name}-${nanoid()}`,
   });
   Injectable()(mixinClass);
   return mixinClass;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1926,11 +1926,6 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@types/shortid@^0.0.29":
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/@types/shortid/-/shortid-0.0.29.tgz#8093ee0416a6e2bf2aa6338109114b3fbffa0e9b"
-  integrity sha1-gJPuBBam4r8qpjOBCRFLP7/6Dps=
-
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
@@ -7267,10 +7262,10 @@ mz@^2.5.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nanoid@^2.1.0:
-  version "2.1.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
-  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
+nanoid@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
+  integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -8908,13 +8903,6 @@ shelljs@0.7.6:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
-
-shortid@^2.2.14:
-  version "2.2.16"
-  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.16.tgz#b742b8f0cb96406fd391c76bfc18a67a57fe5608"
-  integrity sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==
-  dependencies:
-    nanoid "^2.1.0"
 
 side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Fixes https://github.com/golevelup/nestjs/issues/383

Replace the deprecated and vulnerable shortid dependency with nanoid, a faster and secure alternative.

Current code will generate 20-letters random ids instead of the previous 7-letters.