### PR TITLE
feat: RabbitMQ module lifecycle change

### DIFF
--- a/integration/rabbitmq/src/main.ts
+++ b/integration/rabbitmq/src/main.ts
@@ -3,6 +3,7 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.enableShutdownHooks();
   await app.listen(3000);
 }
 void bootstrap();

--- a/packages/rabbitmq/src/rabbitmq.module.ts
+++ b/packages/rabbitmq/src/rabbitmq.module.ts
@@ -6,9 +6,9 @@ import {
 import {
   DynamicModule,
   Module,
-  OnModuleInit,
-  OnModuleDestroy,
   ConsoleLogger,
+  OnApplicationBootstrap,
+  OnApplicationShutdown,
 } from '@nestjs/common';
 import { ExternalContextCreator } from '@nestjs/core/helpers/external-context-creator';
 import { groupBy } from 'lodash';
@@ -42,7 +42,7 @@ export class RabbitMQModule
       exports: [AmqpConnection],
     }
   )
-  implements OnModuleDestroy, OnModuleInit
+  implements OnApplicationBootstrap, OnApplicationShutdown
 {
   private readonly logger = new ConsoleLogger(RabbitMQModule.name);
 
@@ -94,12 +94,12 @@ export class RabbitMQModule
     };
   }
 
-  async onModuleDestroy() {
+  async onApplicationShutdown() {
     this.logger.verbose('Closing AMQP Connection');
     await this.amqpConnection.managedConnection.close();
   }
 
-  public async onModuleInit() {
+  public async onApplicationBootstrap() {
     if (!this.amqpConnection.configuration.registerHandlers) {
       this.logger.log(
         'Skipping RabbitMQ Handlers due to configuration. This application instance will not receive messages over RabbitMQ'


### PR DESCRIPTION
Changed the module initialization and destructing onto the nestjs application lifecycle
Another side note would be that the integration app is now using shutdown hooks in order to allow us to debug/running the `shutdown` hook (more details at: https://docs.nestjs.com/fundamentals/lifecycle-events#application-shutdown)

This PR fixes #386 