### PR TITLE
Revert logger usage

### DIFF
--- a/packages/hasura/src/hasura.module.ts
+++ b/packages/hasura/src/hasura.module.ts
@@ -2,7 +2,7 @@ import { DiscoveryModule, DiscoveryService } from '@golevelup/nestjs-discovery';
 import { createConfigurableDynamicRootModule } from '@golevelup/nestjs-modules';
 import {
   BadRequestException,
-  ConsoleLogger,
+  Logger,
   Module,
   OnModuleInit,
 } from '@nestjs/common';
@@ -74,7 +74,7 @@ export class HasuraModule
   )
   implements OnModuleInit
 {
-  private readonly logger = new ConsoleLogger(HasuraModule.name);
+  private readonly logger = new Logger(HasuraModule.name);
 
   constructor(
     private readonly discover: DiscoveryService,

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -1,4 +1,4 @@
-import { ConsoleLogger } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
 import {
   ChannelWrapper,
   AmqpConnectionManager,
@@ -62,9 +62,7 @@ const defaultConfig = {
 
 export class AmqpConnection {
   private readonly messageSubject = new Subject<CorrelationMessage>();
-  private readonly logger: ConsoleLogger = new ConsoleLogger(
-    AmqpConnection.name
-  );
+  private readonly logger = new Logger(AmqpConnection.name);
   private readonly initialized = new Subject<void>();
   private _managedConnection!: AmqpConnectionManager;
   /**

--- a/packages/rabbitmq/src/rabbitmq.module.ts
+++ b/packages/rabbitmq/src/rabbitmq.module.ts
@@ -8,7 +8,7 @@ import {
   Module,
   OnModuleInit,
   OnModuleDestroy,
-  ConsoleLogger,
+  Logger,
 } from '@nestjs/common';
 import { ExternalContextCreator } from '@nestjs/core/helpers/external-context-creator';
 import { groupBy } from 'lodash';
@@ -44,7 +44,7 @@ export class RabbitMQModule
   )
   implements OnModuleDestroy, OnModuleInit
 {
-  private readonly logger = new ConsoleLogger(RabbitMQModule.name);
+  private readonly logger = new Logger(RabbitMQModule.name);
 
   constructor(
     private readonly discover: DiscoveryService,
@@ -57,13 +57,13 @@ export class RabbitMQModule
   static async AmqpConnectionFactory(config: RabbitMQConfig) {
     const connection = new AmqpConnection(config);
     await connection.init();
-    const logger = new ConsoleLogger(RabbitMQModule.name);
+    const logger = new Logger(RabbitMQModule.name);
     logger.log('Successfully connected to RabbitMQ');
     return connection;
   }
 
   public static build(config: RabbitMQConfig): DynamicModule {
-    const logger = new ConsoleLogger(RabbitMQModule.name);
+    const logger = new Logger(RabbitMQModule.name);
     logger.warn(
       'build() is deprecated. use forRoot() or forRootAsync() to configure RabbitMQ'
     );

--- a/packages/stripe/src/stripe.module.ts
+++ b/packages/stripe/src/stripe.module.ts
@@ -1,6 +1,6 @@
 import { DiscoveryModule, DiscoveryService } from '@golevelup/nestjs-discovery';
 import { createConfigurableDynamicRootModule } from '@golevelup/nestjs-modules';
-import { ConsoleLogger, Module, OnModuleInit } from '@nestjs/common';
+import { Logger, Module, OnModuleInit } from '@nestjs/common';
 import { PATH_METADATA } from '@nestjs/common/constants';
 import { ExternalContextCreator } from '@nestjs/core/helpers/external-context-creator';
 import { flatten, groupBy } from 'lodash';
@@ -68,7 +68,7 @@ export class StripeModule
   )
   implements OnModuleInit
 {
-  private readonly logger = new ConsoleLogger(StripeModule.name);
+  private readonly logger = new Logger(StripeModule.name);
 
   constructor(
     private readonly discover: DiscoveryService,


### PR DESCRIPTION
@WonderPanda After confirming with Jay it seems that `ConsoleLogger` should only be used at a consumer level which means, as the producers need to extend the `Logger` service. The docs do not explain this for module creators but this is intended and after confirming it I don't believe it is a regression

This will fix #379