### PR TITLE
feat: RabbitMQ module drop support for build method

### DIFF
--- a/packages/rabbitmq/src/rabbitmq.module.ts
+++ b/packages/rabbitmq/src/rabbitmq.module.ts
@@ -62,25 +62,6 @@ export class RabbitMQModule
     return connection;
   }
 
-  public static build(config: RabbitMQConfig): DynamicModule {
-    const logger = new ConsoleLogger(RabbitMQModule.name);
-    logger.warn(
-      'build() is deprecated. use forRoot() or forRootAsync() to configure RabbitMQ'
-    );
-    return {
-      module: RabbitMQModule,
-      providers: [
-        {
-          provide: AmqpConnection,
-          useFactory: async (): Promise<AmqpConnection> => {
-            return RabbitMQModule.AmqpConnectionFactory(config);
-          },
-        },
-      ],
-      exports: [AmqpConnection],
-    };
-  }
-
   public static attach(connection: AmqpConnection): DynamicModule {
     return {
       module: RabbitMQModule,


### PR DESCRIPTION
BREAKING CHANGE: Any app that still uses build should use forRoot or forRootAsync
