### PR TITLE
docs(readme.md): fix webhooks README.md wording

### DIFF
--- a/packages/webhooks/README.md
+++ b/packages/webhooks/README.md
@@ -42,24 +42,7 @@ const app = await NestFactory.create(AppModule, {
 });
 ```
 
-#### Step 2: Include middlewares in your AppModule
-
-```typescript
-import {
-  JsonBodyMiddleware,
-  RawBodyMiddleware,
-} from '@golevelup/nestjs-webhooks';
-```
-
-In your `AppModule` (or equivalent top level module), include both of the above middleware in your `providers` array:
-
-```typescript
-@Module({
-    providers: [JsonBodyMiddleware, RawBodyMiddleware]
-})
-```
-
-#### Step 3: Configure Middleware Routes
+#### Step 2: Configure Middleware Routes
 
 If your AppModule doesn't already, implement the `NestModule` interface from `@nestjs/common`. This will allow you to [apply middleware to specific routes](https://docs.nestjs.com/middleware#applying-middleware).
 

--- a/packages/webhooks/README.md
+++ b/packages/webhooks/README.md
@@ -51,11 +51,11 @@ import {
 } from '@golevelup/nestjs-webhooks';
 ```
 
-In your `AppModule` (or equivalent top level module), include both of the above middleware in your `imports` array:
+In your `AppModule` (or equivalent top level module), include both of the above middleware in your `providers` array:
 
 ```typescript
 @Module({
-    imports: [JsonBodyMiddleware, RawBodyMiddleware]
+    providers: [JsonBodyMiddleware, RawBodyMiddleware]
 })
 ```
 


### PR DESCRIPTION
Changes `imports` to `providers` in webhooks `README.md`