### PR TITLE
feat(connection): reconsume

### DIFF
--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -38,7 +38,6 @@ import { isNull } from 'lodash';
 
 const DIRECT_REPLY_QUEUE = 'amq.rabbitmq.reply-to';
 
-
 export type ConsumerTag = string;
 
 export type SubscriberHandler<T = unknown> = (
@@ -356,7 +355,7 @@ export class AmqpConnection {
     handler: SubscriberHandler<T>,
     msgOptions: MessageHandlerOptions,
     channel: ConfirmChannel,
-    originalHandlerName: string
+    originalHandlerName = 'unknown'
   ): Promise<void> {
     const queue = await this.setupQueue(msgOptions, channel);
 

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -611,16 +611,16 @@ export class AmqpConnection {
     this._consumers.push(consumer);
   }
 
+  private getConsumerIdx(consumerTag: string) {
+    return this._consumers.findIndex((x) => x.consumerTag === consumerTag)
+  }
+
   private unregisterConsumerForQueue<T, U>(consumerTag: string) {
-    const idx = this._consumers.indexOf(consumerTag)
+    const idx = this.getConsumerIdx(consumerTag)
     if (idx === -1) {
       return;
     }
     this._consumers.splice(idx, 1);
-  }
-
-  private getConsumerIdx(consumerTag: string) {
-    return this._consumers.findIndex((x) => x.consumerTag === consumerTag)
   }
 
   private getConsumer(consumerTag: string) {

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -637,18 +637,20 @@ export class AmqpConnection {
 
   public async resumeConsumer(consumerTag: string) {
     const consumer = this.getConsumer(consumerTag);
-    await consumer.type === 'rpc'
-      ? this.setupRpcChannel(
-        consumer.handler,
-        consumer.rpcOptions,
-        consumer.channel
-      )
-      : this.setupSubscriberChannel(
-        consumer.handler,
-        consumer.msgOptions,
-        consumer.channel
-      );
-    // A new consumerTag was created, remove old
-    this.unregisterConsumerForQueue(consumerTag);
+    if (consumer) {
+      await consumer.type === 'rpc'
+        ? this.setupRpcChannel(
+          consumer.handler,
+          consumer.rpcOptions,
+          consumer.channel
+        )
+        : this.setupSubscriberChannel(
+          consumer.handler,
+          consumer.msgOptions,
+          consumer.channel
+        );
+      // A new consumerTag was created, remove old
+      this.unregisterConsumerForQueue(consumerTag);
+    }
   }
 }

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -648,6 +648,7 @@ export class AmqpConnection {
         consumer.msgOptions,
         consumer.channel
       );
+    // A new consumerTag was created, remove old
     this.unregisterConsumerForQueue(consumerTag);
   }
 }

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -37,18 +37,18 @@ import { Nack, RpcResponse, SubscribeResponse } from './handlerResponses';
 
 const DIRECT_REPLY_QUEUE = 'amq.rabbitmq.reply-to';
 
-type ConsumerTag = string;
+export type ConsumerTag = string;
 export interface CorrelationMessage {
   correlationId: string;
   message: Record<string, unknown>;
 }
 
-type BaseConsumerHandler = {
+export type BaseConsumerHandler = {
   consumerTag: string;
   channel: ConfirmChannel;
 };
 
-type ConsumerHandler<T, U> =
+export type ConsumerHandler<T, U> =
   | (BaseConsumerHandler & {
       type: 'subscribe';
       msgOptions: MessageHandlerOptions;


### PR DESCRIPTION
When dependencies of a Microservice are offline it is beneficial to stop the consumer and only
restart when work is ready to be continued. 

This saves a lot of rabbit bandwidth not needing to deliver nack requeue over and over until the consumer is ready.