### PR TITLE
feat(hasura): implements a service to create and delete one off scheduled events

### DIFF
--- a/packages/hasura/package-lock.json
+++ b/packages/hasura/package-lock.json
@@ -4,74 +4,79 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@golevelup/nestjs-common": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@golevelup/nestjs-common/-/nestjs-common-1.4.3.tgz",
-      "integrity": "sha512-ArEC1esJZWZZhEqV6KgzPflZgnVOsdswJTykwgLpX+QgIhSFmGx5W+veetf2Aky3hM5p6liTNYlBR6rvVJ/zsA==",
+    "@nestjs/axios": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-0.0.8.tgz",
+      "integrity": "sha512-oJyfR9/h9tVk776il0829xyj3b2e81yTu6HjPraxynwNtMNGqZBHHmAQL24yMB3tVbBM0RvG3eUXH8+pRCGwlg==",
       "requires": {
-        "nanoid": "^3.2.0"
+        "axios": "0.27.2"
       }
-    },
-    "@golevelup/nestjs-discovery": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@golevelup/nestjs-discovery/-/nestjs-discovery-3.0.0.tgz",
-      "integrity": "sha512-ZvkXtobTKxXB1LJanP/l6Z/Fing88IMBr3uabQpU2IWjfsstjh02qYDSU2cfD6CSmNldX5ewW5Pd+SdK2lU8Sw==",
-      "requires": {
-        "lodash": "^4.17.15"
-      }
-    },
-    "@golevelup/nestjs-modules": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@golevelup/nestjs-modules/-/nestjs-modules-0.5.0.tgz",
-      "integrity": "sha512-6ZGjPtm0KwJ7Txa3Z14IzILi7pfvGrLZHv/q9/4tt7T5ngcCe71wJp32TG0/b3UkJX3/LEm4AtYjcfwiIrfSlg==",
-      "requires": {
-        "lodash": "^4.17.21"
-      }
-    },
-    "@hasura/metadata": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@hasura/metadata/-/metadata-1.0.2.tgz",
-      "integrity": "sha512-bVDwRWC7g/NfLVUwP8HBV07+37g07UAbF+XEujfRmgr8839sH7Q2iwa2M8oQFQXwg4dj5Sn+WRt4/UWXKN7naQ=="
-    },
-    "@types/js-yaml": {
-      "version": "3.12.7",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.7.tgz",
-      "integrity": "sha512-S6+8JAYTE1qdsc9HMVsfY7+SgSuUU/Tp6TYTmITW0PZxiyIMvol3Gy//y69Wkhs0ti4py5qgR3uZH6uz/DNzJQ==",
-      "dev": true
     },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "follow-redirects": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "js-yaml": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "requires": {
         "argparse": "^2.0.1"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
-    "nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
-    },
-    "ts-toolbelt": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
-      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
-      "dev": true
-    },
-    "zod": {
-      "version": "3.11.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.11.6.tgz",
-      "integrity": "sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg=="
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
     }
   }
 }

--- a/packages/hasura/package.json
+++ b/packages/hasura/package.json
@@ -40,6 +40,7 @@
     "@golevelup/nestjs-discovery": "^3.0.0",
     "@golevelup/nestjs-modules": "^0.5.0",
     "@hasura/metadata": "^1.0.2",
+    "@nestjs/axios": "0.0.8",
     "js-yaml": "^4.1.0",
     "zod": "^3.3.4"
   },

--- a/packages/hasura/src/hasura-metadata-dist/HasuraMetadataV2.d.ts
+++ b/packages/hasura/src/hasura-metadata-dist/HasuraMetadataV2.d.ts
@@ -186,7 +186,7 @@ export interface CronTrigger {
   /**
    * Cron expression at which the trigger should be invoked.
    */
-  schedule: string;
+  schedule?: string;
   /**
    * URL of the webhook
    */
@@ -1090,9 +1090,7 @@ export declare class Convert {
   static tableEntryToJson(value: TableEntry): string;
   static toCustomRootFields(json: string): CustomRootFields;
   static customRootFieldsToJson(value: CustomRootFields): string;
-  static toCustomColumnNames(
-    json: string
-  ): {
+  static toCustomColumnNames(json: string): {
     [key: string]: string;
   };
   static customColumnNamesToJson(value: { [key: string]: string }): string;
@@ -1122,9 +1120,7 @@ export declare class Convert {
   static arrRelUsingManualMappingToJson(
     value: ArrRelUsingManualMapping
   ): string;
-  static toColumnPresetsExpression(
-    json: string
-  ): {
+  static toColumnPresetsExpression(json: string): {
     [key: string]: string;
   };
   static columnPresetsExpressionToJson(value: {
@@ -1176,15 +1172,11 @@ export declare class Convert {
   static remoteRelationshipToJson(value: RemoteRelationship): string;
   static toRemoteRelationshipDef(json: string): RemoteRelationshipDef;
   static remoteRelationshipDefToJson(value: RemoteRelationshipDef): string;
-  static toRemoteField(
-    json: string
-  ): {
+  static toRemoteField(json: string): {
     [key: string]: RemoteField;
   };
   static remoteFieldToJson(value: { [key: string]: RemoteField }): string;
-  static toInputArguments(
-    json: string
-  ): {
+  static toInputArguments(json: string): {
     [key: string]: string;
   };
   static inputArgumentsToJson(value: { [key: string]: string }): string;

--- a/packages/hasura/src/hasura.constants.ts
+++ b/packages/hasura/src/hasura.constants.ts
@@ -1,5 +1,16 @@
 export const HASURA_EVENT_HANDLER = Symbol('HASURA_EVENT_HANDLER');
 export const HASURA_MODULE_CONFIG = Symbol('HASURA_MODULE_CONFIG');
+export const HASURA_SERVICE_CONFIG = Symbol('HASURA_MODULE_CONFIG');
 export const HASURA_SCHEDULED_EVENT_HANDLER = Symbol(
   'HASURA_SCHEDULED_EVENT_HANDLER'
 );
+
+// We need string literal
+export const enum ScheduledEventRequest {
+  CREATE_SCHEDULED_EVENT = 'create_scheduled_event',
+  DELETE_SCHEDULED_EVENT = 'delete_scheduled_event',
+}
+export const enum ScheduledEventMode {
+  ONE_OFF = 'one_off',
+  CRON = 'cron',
+}

--- a/packages/hasura/src/hasura.event-handler.controller.ts
+++ b/packages/hasura/src/hasura.event-handler.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  HttpCode,
+  Post,
+  Headers,
+  UseGuards,
+} from '@nestjs/common';
 import { HasuraEventHandlerHeaderGuard } from './hasura.event-handler.guard';
 import { EventHandlerService } from './hasura.event-handler.service';
 import { HasuraEvent } from './hasura.interfaces';
@@ -10,8 +17,11 @@ export class EventHandlerController {
   @UseGuards(HasuraEventHandlerHeaderGuard)
   @Post('/events')
   @HttpCode(202)
-  async handleEvent(@Body() evt: HasuraEvent) {
-    const response = await this.eventHandlerService.handleEvent(evt);
+  async handleEvent(
+    @Body() evt: HasuraEvent,
+    @Headers() headers: typeof Headers
+  ) {
+    const response = await this.eventHandlerService.handleEvent(evt, headers);
     return response == undefined ? { success: true } : response;
   }
 }

--- a/packages/hasura/src/hasura.event-handler.service.ts
+++ b/packages/hasura/src/hasura.event-handler.service.ts
@@ -1,10 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import { Headers, Injectable } from '@nestjs/common';
 import { HasuraEvent } from './hasura.interfaces';
 
 @Injectable()
 export class EventHandlerService {
-  public handleEvent(evt: HasuraEvent): any {
+  public handleEvent(evt: HasuraEvent, headers: typeof Headers): any {
     // The implementation for this method is overriden by the containing module
-    console.log(evt);
+    console.log(evt, headers);
   }
 }

--- a/packages/hasura/src/hasura.interfaces.ts
+++ b/packages/hasura/src/hasura.interfaces.ts
@@ -1,3 +1,5 @@
+import { ScheduledEventMode } from './hasura.constants';
+
 const exampleEvent = {
   id: 'ecd5fe4a-7113-4243-bb0e-6177c78a0033',
   table: { schema: 'public', name: 'user' },
@@ -110,7 +112,51 @@ export interface HasuraScheduledEventPayload<T = Record<string, any>> {
   name: string;
   created_at: Date;
   id: string;
+}
+
+export type HasuraScheduledEventType =
+  | 'create_scheduled_event'
+  | 'delete_scheduled_event';
+
+export interface HasuraScheduledEvent<T = Record<string, any>> {
+  scheduled_time?: Date;
+  payload: T;
+  name?: string;
   comment?: string;
+  /* optional webhook_url to override the webhook provided by this package */
+  webhook_url?: string;
+}
+
+export interface CreateHasuraScheduledEventBody<T = Record<string, unknown>> {
+  type: HasuraScheduledEventType;
+  args: {
+    webhook: string;
+    schedule_at?: Date;
+    payload: T;
+    headers: {
+      name: string;
+      value?: string;
+      value_from_env?: string;
+    }[];
+    comment?: string;
+  };
+}
+
+export interface DeleteHasuraScheduledEventBody {
+  type: HasuraScheduledEventType;
+  args: {
+    type: ScheduledEventMode;
+    event_id: string;
+  };
+}
+
+export interface HasuraServiceConfig {
+  endpoint: string;
+  adminSecret: string;
+  nestEndpointEnvName: string;
+  secretHeaderEnvName: string;
+  secretHeader: string;
+  scheduledEventsHeader: string;
 }
 
 export interface HasuraModuleConfig {
@@ -129,7 +175,7 @@ export interface HasuraModuleConfig {
     /**
      * The root endpoint for Hasura's GraphQL API. e.g. http://localhost:8080
      */
-    rootEndpoint: string;
+    rootEndpoint?: string;
     /**
      * The value of the secret Header. The Hasura module will ensure that incoming webhook payloads contain this
      * value in order to validate that it is a trusted request

--- a/packages/hasura/src/hasura.interfaces.ts
+++ b/packages/hasura/src/hasura.interfaces.ts
@@ -90,7 +90,7 @@ export interface TrackedHasuraEventHandlerConfig {
 
 export interface TrackedHasuraScheduledEventHandlerConfig {
   name: string;
-  cronSchedule: string;
+  cronSchedule?: string;
   payload: any;
   comment?: string;
   retryConfig?: ScheduledEventRetryConfig;
@@ -110,6 +110,7 @@ export interface HasuraScheduledEventPayload<T = Record<string, any>> {
   name: string;
   created_at: Date;
   id: string;
+  comment?: string;
 }
 
 export interface HasuraModuleConfig {
@@ -121,7 +122,14 @@ export interface HasuraModuleConfig {
      * The name of the Header that Hasura will send along with all event payloads
      */
     secretHeader: string;
-
+    /**
+     * The name of the Header to identify Hasura Scheduled Events created by the service
+     */
+    scheduledEventsHeader: string;
+    /**
+     * The root endpoint for Hasura's GraphQL API. e.g. http://localhost:8080
+     */
+    rootEndpoint: string;
     /**
      * The value of the secret Header. The Hasura module will ensure that incoming webhook payloads contain this
      * value in order to validate that it is a trusted request

--- a/packages/hasura/src/hasura.interfaces.ts
+++ b/packages/hasura/src/hasura.interfaces.ts
@@ -93,7 +93,7 @@ export interface TrackedHasuraEventHandlerConfig {
 export interface TrackedHasuraScheduledEventHandlerConfig {
   name: string;
   cronSchedule?: string;
-  payload: any;
+  payload?: any;
   comment?: string;
   retryConfig?: ScheduledEventRetryConfig;
 }

--- a/packages/hasura/src/hasura.metadata.ts
+++ b/packages/hasura/src/hasura.metadata.ts
@@ -44,7 +44,7 @@ const updateEventTriggerMetaV2 = (
   const defaultRetryConfig =
     managedMetaDataConfig.defaultEventRetryConfig ?? defaultHasuraRetryConfig;
 
-  const tablesYamlPath = `${managedMetaDataConfig.dirPath}/tables.yaml`;
+  const tablesYamlPath = `${managedMetaDataConfig.dirPath}/metadata/tables.yaml`;
 
   const tablesMeta = readFileSync(tablesYamlPath, utf8);
   const tableEntries = load(tablesMeta) as TableEntry[];
@@ -90,7 +90,7 @@ const updateEventTriggerMetaV3 = (
   eventHandlerConfigs.forEach((config) => {
     const { schema = 'public', databaseName = 'default', tableName } = config;
 
-    const tableYamlPath = `${managedMetaDataConfig.dirPath}/databases/${databaseName}/tables/${schema}_${tableName}.yaml`;
+    const tableYamlPath = `${managedMetaDataConfig.dirPath}/metadata/databases/${databaseName}/tables/${schema}_${tableName}.yaml`;
     const tableMeta = readFileSync(tableYamlPath, utf8);
     const tableEntry = load(tableMeta) as TableEntry;
 
@@ -137,7 +137,7 @@ export const updateScheduledEventTriggerMeta = (
     throw new Error(MISSING_META_CONFIG);
   }
 
-  const cronTriggersYamlPath = `${managedMetaDataConfig.dirPath}/cron_triggers.yaml`;
+  const cronTriggersYamlPath = `${managedMetaDataConfig.dirPath}/metadata/cron_triggers.yaml`;
 
   const cronTriggersMeta = readFileSync(cronTriggersYamlPath, utf8);
   const cronEntries = (load(cronTriggersMeta) ?? []) as CronTrigger[];

--- a/packages/hasura/src/hasura.module.ts
+++ b/packages/hasura/src/hasura.module.ts
@@ -57,7 +57,6 @@ function isHasuraScheduledEventPayload(
         const configPath = `${hasuraModuleConfig.managedMetaDataConfig?.dirPath}/config.yaml`;
         const configYaml = readFileSync(configPath, 'utf8');
         const configJson = load(configYaml);
-        console.log(hasuraModuleConfig);
         return {
           endpoint:
             hasuraModuleConfig.webhookConfig.rootEndpoint ||

--- a/packages/hasura/src/hasura.service.ts
+++ b/packages/hasura/src/hasura.service.ts
@@ -1,0 +1,109 @@
+import { HttpService } from '@nestjs/axios';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { lastValueFrom } from 'rxjs';
+import {
+  ScheduledEventRequest,
+  HASURA_SERVICE_CONFIG,
+  ScheduledEventMode,
+} from './hasura.constants';
+import {
+  HasuraServiceConfig,
+  HasuraScheduledEvent,
+  CreateHasuraScheduledEventBody,
+  DeleteHasuraScheduledEventBody,
+} from './hasura.interfaces';
+
+@Injectable()
+export class HasuraService {
+  constructor(
+    private httpService: HttpService,
+    @Inject(HASURA_SERVICE_CONFIG)
+    private hasuraServiceConfig: HasuraServiceConfig
+  ) {}
+
+  async createScheduledEvent({
+    name,
+    comment,
+    scheduled_time,
+    payload,
+    webhook_url,
+  }: HasuraScheduledEvent): Promise<{ message: string; event_id: string }> {
+    const body = this.generateCreateEventBody({
+      name,
+      payload,
+      comment,
+      scheduled_time,
+      webhook_url,
+    });
+    try {
+      const source$ = this.hasuraScheduledEventRequest(body);
+      return lastValueFrom(source$).then((r) => r.data);
+    } catch (error) {
+      throw new BadRequestException(error);
+    }
+  }
+
+  async deleteScheduledEvent(
+    eventId: string,
+    type: ScheduledEventMode
+  ): Promise<{ message: string }> {
+    const body = {
+      type: ScheduledEventRequest.DELETE_SCHEDULED_EVENT,
+      args: {
+        type,
+        event_id: eventId,
+      },
+    };
+    try {
+      const source$ = this.hasuraScheduledEventRequest(body);
+      return lastValueFrom(source$).then((r) => r.data);
+    } catch (error) {
+      console.log(error);
+      throw new BadRequestException(error);
+    }
+  }
+
+  private hasuraScheduledEventRequest(
+    body: CreateHasuraScheduledEventBody | DeleteHasuraScheduledEventBody
+  ) {
+    return this.httpService.post(
+      `${this.hasuraServiceConfig.endpoint}/v1/metadata`,
+      body,
+      {
+        headers: {
+          'X-Hasura-Admin-Secret': this.hasuraServiceConfig.adminSecret,
+        },
+      }
+    );
+  }
+
+  private generateCreateEventBody({
+    name,
+    payload,
+    comment,
+    scheduled_time,
+    webhook_url,
+  }: HasuraScheduledEvent) {
+    return {
+      type: ScheduledEventRequest.CREATE_SCHEDULED_EVENT,
+      args: {
+        webhook: webhook_url
+          ? webhook_url
+          : `{{${this.hasuraServiceConfig.nestEndpointEnvName}}}`,
+        schedule_at: scheduled_time,
+        payload,
+        headers: [
+          {
+            name: this.hasuraServiceConfig.secretHeader,
+            value_from_env: this.hasuraServiceConfig.secretHeaderEnvName,
+          },
+          {
+            name: this.hasuraServiceConfig.scheduledEventsHeader,
+            value: name,
+          },
+        ],
+        comment: comment,
+      },
+    };
+  }
+}

--- a/packages/hasura/src/hasura.service.ts
+++ b/packages/hasura/src/hasura.service.ts
@@ -58,7 +58,6 @@ export class HasuraService {
       const source$ = this.hasuraScheduledEventRequest(body);
       return lastValueFrom(source$).then((r) => r.data);
     } catch (error) {
-      console.log(error);
       throw new BadRequestException(error);
     }
   }

--- a/packages/hasura/src/index.ts
+++ b/packages/hasura/src/index.ts
@@ -2,3 +2,4 @@ export * from './hasura.constants';
 export * from './hasura.decorators';
 export * from './hasura.interfaces';
 export * from './hasura.module';
+export * from './hasura.service';

--- a/packages/hasura/src/tests/hasura.event-handling.spec.ts
+++ b/packages/hasura/src/tests/hasura.event-handling.spec.ts
@@ -90,6 +90,8 @@ describe.each(cases)(
       webhookConfig: {
         secretFactory: secret,
         secretHeader: secretHeader,
+        rootEndpoint: 'http://localhost:3000',
+        scheduledEventsHeader: 'nestjs-event-name',
       },
       controllerPrefix,
       enableEventLogs: true,
@@ -177,6 +179,8 @@ describe('HasuraModule with Custom Decorator', () => {
           webhookConfig: {
             secretHeader,
             secretFactory: secret,
+            rootEndpoint: 'http://localhost:3000',
+            scheduledEventsHeader: 'nestjs-event-name',
           },
         }),
       ],

--- a/packages/hasura/src/tests/hasura.metadata.spec-utils.ts
+++ b/packages/hasura/src/tests/hasura.metadata.spec-utils.ts
@@ -16,6 +16,8 @@ export const baseConfig = {
   webhookConfig: {
     secretFactory: 'secret',
     secretHeader: 'NESTJS_SECRET_HEADER',
+    scheduledEventsHeader: 'NESTJS_SCHEDULED_EVENTS_HEADER',
+    rootEndpoint: 'NESTJS_ROOT_ENDPOINT',
   },
   managedMetaDataConfig: {
     secretHeaderEnvName: 'NESTJS_WEBHOOK_SECRET_HEADER_VALUE',

--- a/packages/hasura/src/tests/hasura.metadata.spec-utils.ts
+++ b/packages/hasura/src/tests/hasura.metadata.spec-utils.ts
@@ -40,18 +40,15 @@ export const getVersionedMetadataPathAndConfig = (
   v: string
 ): [string, HasuraModuleConfig] => {
   const version = metadataVersion.parse(v);
-  const metadataPath = path.join(
-    __dirname,
-    `../../test/__fixtures__/hasura/${version}/metadata`
-  );
+  const hasuraPath = path.join(__dirname, `../../test/__fixtures__/hasura`);
 
   const { managedMetaDataConfig } = baseConfig;
   return [
-    metadataPath,
+    hasuraPath,
     {
       ...baseConfig,
       managedMetaDataConfig: {
-        dirPath: metadataPath,
+        dirPath: hasuraPath,
         metadataVersion: version,
         ...managedMetaDataConfig,
       },


### PR DESCRIPTION
## Breaking changes

- Replaces dirPath config from metadata directory with the root config directory: instead of `dirPath: join(process.cwd(), 'hasura/metadata')`, should be `dirPath: join(process.cwd(), 'hasura')`

### New Features
- This PR introduces the possibility to create One Off Scheduled Events via an Injectable Service. New configuration:

```js
import { HasuraModule } from https://github.com/golevelup/nestjs;

@Module({
  imports: [
    HasuraModule.forRoot(HasuraModule, {
      webhookConfig: {
        secretFactory: secret,
        secretHeader: secretHeader,
        scheduledEventsHeader: 'nestjs-event-name',
        rootEndpoint: 'http://localhost:8080' /* optional: it will fallback to the root URL from Hasura config */
      },
      managedMetaDataConfig: {
        dirPath: join(process.cwd(), 'hasura') /* required: we now need to pass the root config directory */,
        secretHeaderEnvName: 'HASURA_NESTJS_WEBHOOK_SECRET_HEADER_VALUE',
        nestEndpointEnvName: 'NESTJS_EVENT_WEBHOOK_ENDPOINT',
        defaultEventRetryConfig: {
          intervalInSeconds: 15,
          numRetries: 3,
          timeoutInSeconds: 100,
          toleranceSeconds: 21600,
        },
      },
    }),
  ],
})
export class AppModule {
  // ...
}
```

To use this service inject it in the constructor of one of your services:

```js
constructor(private readonly hasuraService: HasuraService) {}
```

and then schedule a new event:

```js
const scheduledTime = add(
  new Date(
    new Date().toLocaleString("en-US", {
      timeZone: "Europe/Madrid",
    })
  ),
  { weeks: 1 }
);
const event = await this.hasuraService.createScheduledEvent({
  name: "send-email-one-week",
  comment: "",
  scheduled_time: scheduledTime,
  payload: {},
});
```

There's also a convenient `webhook_url` parameter that you can use to pass an arbitrary webhook to handle it outside of the NestJS app, but it has a trade off, you need to pass the webhook secret in `payload` and validate manually, but thought it was a _nice to have_.

---
Finally, to receive the event just decorate your handler with:

```ts
@TrackedHasuraScheduledEventHandler({ name: "send-email-one-week" })
emailUser() {
   console.log("emailUser");
}
```

I also added a method to delete one off events:

``` ts
// import { ScheduledEventMode } from "@golevelup/nestjs-hasura"
await this.hasuraService.deleteScheduledEvent("event_id", ScheduledEventMode.ONE_OFF)
```

### WIP:

- Tests