### PR TITLE
Set specific type names for our execution contexts

### DIFF
--- a/packages/hasura/src/hasura.module.ts
+++ b/packages/hasura/src/hasura.module.ts
@@ -148,7 +148,13 @@ export class HasuraModule
             handler: this.externalContextCreator.create(
               discoveredMethod.parentClass.instance,
               discoveredMethod.handler,
-              discoveredMethod.methodName
+              discoveredMethod.methodName,
+              undefined, // metadataKey
+              undefined, // paramsFactory
+              undefined, // contextId
+              undefined, // inquirerId
+              undefined, // options
+              'hasura_event' // contextType
             ),
           };
         });

--- a/packages/rabbitmq/README.md
+++ b/packages/rabbitmq/README.md
@@ -16,7 +16,7 @@
   - [Usage](#usage)
     - [Install](#install)
     - [Module Initialization](#module-initialization)
-  - [Usage with Interceptors](#usage-with-interceptors)
+  - [Usage with Interceptors, Guards and Filters](#usage-with-interceptors-guards-and-filters)
   - [Usage with Controllers](#usage-with-controllers)
   - [Receiving Messages](#receiving-messages)
     - [Exposing RPC Handlers](#exposing-rpc-handlers)
@@ -133,9 +133,30 @@ import { MessagingService } from './messaging/messaging.service';
 export class RabbitExampleModule {}
 ```
 
-## Usage with Interceptors
+## Usage with Interceptors, Guards and Filters
 
-This library is built using an underlying NestJS concept called `External Contexts` which allows for methods to be included in the NestJS lifecycle. This means that Guards and Interceptors can be used in conjunction with RabbitMQ message handlers. However, this can have unwanted/unintended consequences if you are using Global intereceptors in your application as these will also apply to all RabbitMQ message handlers. As a workaround, there is a utiltity function available called `isRabbitContext` which you can use inside of Interceptors to do conditional logic.
+This library is built using an underlying NestJS concept called `External Contexts` which allows for methods to be included in the NestJS lifecycle. This means that Guards, Interceptors and Filters (collectively known as "enhancers") can be used in conjunction with RabbitMQ message handlers. However, this can have unwanted/unintended consequences if you are using _Global_ enhancers in your application as these will also apply to all RabbitMQ message handlers. If you were previously expecting all contexts to be HTTP contexts, you may need to add conditional logic to prevent your enhancers from applying to RabbitMQ message handlers.
+
+You can identify RabbitMQ contexts by their context type, `'rmq'`:
+
+```typescript
+@Injectable()
+class ExampleInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler<any>) {
+    const contextType = context.getType<'http' | 'rmq'>();
+
+    // Do nothing if this is a RabbitMQ event
+    if (contextType === 'rmq') {
+      return next.handle();
+    }
+
+    // Execute custom interceptor logic for HTTP request/response
+    return next.handle();
+  }
+}
+```
+
+There is also a utility function available called `isRabbitContext` which provides an alternative way to identify RabbitMQ contexts:
 
 ```typescript
 import { isRabbitContext } from '@golevelup/nestjs-rabbitmq';
@@ -143,8 +164,8 @@ import { isRabbitContext } from '@golevelup/nestjs-rabbitmq';
 @Injectable()
 class ExampleInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler<any>) {
-    const shouldSkip = isRabbitContext(context);
-    if (shouldSkip) {
+    // Do nothing if this is a RabbitMQ event
+    if (isRabbitContext(context)) {
       return next.handle();
     }
 

--- a/packages/rabbitmq/src/rabbitmq.module.ts
+++ b/packages/rabbitmq/src/rabbitmq.module.ts
@@ -189,10 +189,10 @@ export class RabbitMQModule
               discoveredMethod.methodName,
               RABBIT_ARGS_METADATA,
               this.rpcParamsFactory,
-              undefined,
-              undefined,
-              undefined,
-              'rmq'
+              undefined, // contextId
+              undefined, // inquirerId
+              undefined, // options
+              'rmq' // contextType
             );
 
             const { exchange, routingKey, queue, queueOptions } = config;

--- a/packages/stripe/README.md
+++ b/packages/stripe/README.md
@@ -27,11 +27,13 @@ Interacting with the Stripe API or consuming Stripe webhooks in your NestJS appl
 #### NPM
 
 - Install the package along with the stripe peer dependency
+
   `npm install --save @golevelup/nestjs-stripe stripe`
 
 #### YARN
 
 - Install the package using yarn with the stripe peer dependency
+
   `yarn add @golevelup/nestjs-stripe stripe`
 
 ### Import

--- a/packages/stripe/README.md
+++ b/packages/stripe/README.md
@@ -27,12 +27,12 @@ Interacting with the Stripe API or consuming Stripe webhooks in your NestJS appl
 #### NPM
 
 - Install the package along with the stripe peer dependency
-`npm install --save @golevelup/nestjs-stripe stripe`
+  `npm install --save @golevelup/nestjs-stripe stripe`
 
 #### YARN
 
 - Install the package using yarn with the stripe peer dependency
-`yarn add @golevelup/nestjs-stripe stripe`
+  `yarn add @golevelup/nestjs-stripe stripe`
 
 ### Import
 
@@ -129,6 +129,29 @@ StripeModule.forRoot(StripeModule, {
     decorators: [ThrottlerSkip()],
   },
 }),
+```
+
+### Usage with Interceptors, Guards and Filters
+
+This library is built using an underlying NestJS concept called `External Contexts` which allows for methods to be included in the NestJS lifecycle. This means that Guards, Interceptors and Filters (collectively known as "enhancers") can be used in conjunction with Stripe webhook handlers. However, this can have unwanted/unintended consequences if you are using _Global_ enhancers in your application as these will also apply to all Stripe webhook handlers. If you were previously expecting all contexts to be regular HTTP contexts, you may need to add conditional logic to prevent your enhancers from applying to Stripe webhook handlers.
+
+You can identify Stripe webhook contexts by their context type, `'stripe_webhook'`:
+
+```typescript
+@Injectable()
+class ExampleInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler<any>) {
+    const contextType = context.getType<'http' | 'stripe_webhook'>();
+
+    // Do nothing if this is a Stripe webhook event
+    if (contextType === 'stripe_webhook') {
+      return next.handle();
+    }
+
+    // Execute custom interceptor logic for HTTP request/response
+    return next.handle();
+  }
+}
 ```
 
 ### Configure Webhooks in the Stripe Dashboard

--- a/packages/stripe/src/stripe.module.ts
+++ b/packages/stripe/src/stripe.module.ts
@@ -130,7 +130,13 @@ export class StripeModule
           handler: this.externalContextCreator.create(
             discoveredMethod.parentClass.instance,
             discoveredMethod.handler,
-            discoveredMethod.methodName
+            discoveredMethod.methodName,
+            undefined, // metadataKey
+            undefined, // paramsFactory
+            undefined, // contextId
+            undefined, // inquirerId
+            undefined, // options
+            'stripe_webhook' // contextType
           ),
         }));
       })


### PR DESCRIPTION
Fixes #454

The NestJS `ExternalContextCreator.create()` method accepts a ninth(!) argument which sets a name for the context type. When omitted, it receives the default value `http`. This can make it difficult for NestJS enhancers (guards, interceptors, filters) to behave correctly when the contexts don't actually have the properties of a real HTTP context.

This PR changes the type for these contexts:

- Stripe module contexts now use the type `stripe_webhook`
- Hasura module contexts now use the type `hasura_event`

RabbitMQ module contexts were already using the type `rmq` since release 2.0.0 (4092c22316023ceacb4218cb30710cc14a4539bd).