### PR TITLE
Returns the ConsumerTag from the createSubscriber() and createRpc() functions

### DIFF
--- a/integration/rabbitmq/e2e/cancel-and-resume.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/cancel-and-resume.e2e-spec.ts
@@ -1,0 +1,87 @@
+import { AmqpConnection, RabbitMQModule } from '@golevelup/nestjs-rabbitmq';
+import { INestApplication, LoggerService } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { createMock } from '@golevelup/ts-jest';
+
+const exchange = 'testCancelAndResumeExchange';
+const queue = 'testCancelAndResumeQueue';
+const routingKey1 = 'testCancelAndResumeRoute1';
+
+describe('Rabbit Cancel and Resume', () => {
+  const customLogger = createMock<LoggerService>({
+    warn: jest.fn(),
+  });
+
+  const rabbitHost =
+    process.env.NODE_ENV === 'ci' ? process.env.RABBITMQ_HOST : 'localhost';
+  const rabbitPort =
+    process.env.NODE_ENV === 'ci' ? process.env.RABBITMQ_PORT : '5672';
+  const uri = `amqp://rabbitmq:rabbitmq@${rabbitHost}:${rabbitPort}`;
+
+  let app: INestApplication;
+  let amqpConnection: AmqpConnection;
+  beforeAll(async () => {
+    const moduleFixture = await Test.createTestingModule({
+      providers: [],
+      imports: [
+        RabbitMQModule.forRoot(RabbitMQModule, {
+          exchanges: [
+            {
+              name: exchange,
+              type: 'topic',
+            },
+          ],
+          uri,
+          connectionInitOptions: { wait: true, reject: true, timeout: 3000 },
+          logger: customLogger,
+        }),
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    amqpConnection = app.get<AmqpConnection>(AmqpConnection);
+    await amqpConnection.channel.assertQueue(queue);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should allow for a ConsumerTag to cancel and resume a subscription', async () => {
+    const subscriptionCallback = jest.fn();
+    const { consumerTag } = await amqpConnection.createSubscriber(
+      (msg) => subscriptionCallback(msg),
+      {
+        exchange,
+        routingKey: [routingKey1],
+        queue: queue,
+      },
+      'testingCallback',
+    );
+    // Make sure the subscription is functional
+    await amqpConnection.publish(exchange, routingKey1, `manual-testMessage-1`);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(subscriptionCallback).toHaveBeenCalledWith(`manual-testMessage-1`);
+    subscriptionCallback.mockReset();
+    // Perform cancel using consumer tag
+    await amqpConnection.cancelConsumer(consumerTag);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    // Make sure published messages are not received by the canceled consumer
+    await amqpConnection.publish(exchange, routingKey1, `manual-testMessage-2`);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(subscriptionCallback).not.toHaveBeenCalled();
+    subscriptionCallback.mockReset();
+    // Resume the consumer
+    await amqpConnection.resumeConsumer(consumerTag);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    // Make sure the subscription was reestablished
+    await amqpConnection.publish(exchange, routingKey1, `manual-testMessage-3`);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(subscriptionCallback).toHaveBeenCalledWith(`manual-testMessage-3`);
+  });
+});

--- a/integration/rabbitmq/e2e/subscribe.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/subscribe.e2e-spec.ts
@@ -185,18 +185,21 @@ describe('Rabbit Subscribe', () => {
       );
       // Make sure the subscription is functional
       amqpConnection.publish(exchange, routingKey1, `testMessage-1`);
+      await new Promise((resolve) => setTimeout(resolve, 50));
       expect(subscriptionCallback).toHaveBeenCalledWith(`testMessage-1`);
       subscriptionCallback.mockReset();
       // Perform cancel using consumer tag
       amqpConnection.channel.cancelConsumer(consumerTag);
       // Make sure the subscription has been canceled
       amqpConnection.publish(exchange, routingKey1, `testMessage-2`);
+      await new Promise((resolve) => setTimeout(resolve, 50));
       expect(subscriptionCallback).not.toHaveBeenCalled();
       subscriptionCallback.mockReset();
       // Resume the consumer
       const newConsumerTag = amqpConnection.channel.resumeConsumer(consumerTag);
       // Make sure the subscription was reestablished
       amqpConnection.publish(exchange, routingKey1, `testMessage-3`);
+      await new Promise((resolve) => setTimeout(resolve, 50));
       expect(subscriptionCallback).toHaveBeenCalledWith(`testMessage-3`);
     });
   });

--- a/integration/rabbitmq/e2e/subscribe.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/subscribe.e2e-spec.ts
@@ -169,6 +169,7 @@ describe('Rabbit Subscribe', () => {
           routingKey: [routingKey1],
           queue: 'subscribeQueue',
         },
+        'testingCallback',
       );
       expect(consumerTag).toBeDefined();
     });
@@ -182,6 +183,7 @@ describe('Rabbit Subscribe', () => {
           routingKey: [routingKey1, routingKey2],
           queue: 'subscribeQueue',
         },
+        'testingCallback',
       );
       // Make sure the subscription is functional
       amqpConnection.publish(exchange, routingKey1, `testMessage-1`);
@@ -189,14 +191,14 @@ describe('Rabbit Subscribe', () => {
       expect(subscriptionCallback).toHaveBeenCalledWith(`testMessage-1`);
       subscriptionCallback.mockReset();
       // Perform cancel using consumer tag
-      amqpConnection.channel.cancelConsumer(consumerTag);
+      amqpConnection.cancelConsumer(consumerTag);
       // Make sure the subscription has been canceled
       amqpConnection.publish(exchange, routingKey1, `testMessage-2`);
       await new Promise((resolve) => setTimeout(resolve, 50));
       expect(subscriptionCallback).not.toHaveBeenCalled();
       subscriptionCallback.mockReset();
       // Resume the consumer
-      const newConsumerTag = amqpConnection.channel.resumeConsumer(consumerTag);
+      const newConsumerTag = amqpConnection.resumeConsumer(consumerTag);
       // Make sure the subscription was reestablished
       amqpConnection.publish(exchange, routingKey1, `testMessage-3`);
       await new Promise((resolve) => setTimeout(resolve, 50));

--- a/integration/rabbitmq/e2e/subscribe.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/subscribe.e2e-spec.ts
@@ -162,7 +162,7 @@ describe('Rabbit Subscribe', () => {
     });
 
     it('should provide a ConsumerTag on subscription', async () => {
-      const consumerTag = await amqpConnection.channel.createSubscriber(
+      const consumerTag = await amqpConnection.createSubscriber(
         (msg) => jest.fn(),
         {
           exchange,
@@ -175,7 +175,7 @@ describe('Rabbit Subscribe', () => {
 
     it('should allow for a ConsumerTag to cancel and resume a subscription', async () => {
       const subscriptionCallback = jest.fn();
-      const consumerTag = await amqpConnection.channel.createSubscriber(
+      const consumerTag = await amqpConnection.createSubscriber(
         (msg) => subscriptionCallback(msg),
         {
           exchange,

--- a/integration/rabbitmq/e2e/subscribe.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/subscribe.e2e-spec.ts
@@ -124,230 +124,137 @@ describe('Rabbit Subscribe', () => {
     process.env.NODE_ENV === 'ci' ? process.env.RABBITMQ_PORT : '5672';
   const uri = `amqp://rabbitmq:rabbitmq@${rabbitHost}:${rabbitPort}`;
 
-  describe('Rabbit Subscribe (Manual)', () => {
-    beforeAll(async () => {
-      const moduleFixture = await Test.createTestingModule({
-        providers: [],
-        imports: [
-          RabbitMQModule.forRoot(RabbitMQModule, {
-            exchanges: [
-              {
-                name: exchange,
-                type: 'topic',
-              },
-              {
-                name: FANOUT,
-                type: FANOUT,
-              },
-            ],
-            uri,
-            connectionInitOptions: { wait: true, reject: true, timeout: 3000 },
-            logger: customLogger,
-          }),
-        ],
-      }).compile();
+  beforeAll(async () => {
+    const moduleFixture = await Test.createTestingModule({
+      providers: [SubscribeService],
+      imports: [
+        RabbitMQModule.forRoot(RabbitMQModule, {
+          exchanges: [
+            {
+              name: exchange,
+              type: 'topic',
+            },
+            {
+              name: FANOUT,
+              type: FANOUT,
+            },
+          ],
+          uri,
+          connectionInitOptions: { wait: true, reject: true, timeout: 3000 },
+          logger: customLogger,
+        }),
+      ],
+    }).compile();
 
-      app = moduleFixture.createNestApplication();
-      amqpConnection = app.get<AmqpConnection>(AmqpConnection);
-      await amqpConnection.channel.assertQueue(preExistingQueue);
-      await app.init();
-    });
-
-    afterAll(async () => {
-      await app?.close();
-    });
-
-    beforeEach(() => {
-      jest.resetAllMocks();
-    });
-
-    it('should provide a ConsumerTag on subscription', async () => {
-      const subscriptionCallback = jest.fn();
-      const { consumerTag } = await amqpConnection.createSubscriber(
-        () => subscriptionCallback(),
-        {
-          exchange,
-          routingKey: [routingKey1],
-          queue: 'subscribeQueue',
-        },
-        'testingCallback',
-      );
-      expect(consumerTag).toBeDefined();
-    });
-
-    it('should allow for a ConsumerTag to cancel and resume a subscription', async () => {
-      const subscriptionCallback = jest.fn();
-      const { consumerTag } = await amqpConnection.createSubscriber(
-        (msg) => subscriptionCallback(msg),
-        {
-          exchange,
-          routingKey: [routingKey1, routingKey2],
-          queue: 'subscribeQueue',
-        },
-        'testingCallback',
-      );
-      // Make sure the subscription is functional
-      await amqpConnection.publish(exchange, routingKey1, `testMessage-1`);
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      expect(subscriptionCallback).toHaveBeenCalledWith(`testMessage-1`);
-      subscriptionCallback.mockReset();
-      // Perform cancel using consumer tag
-      await amqpConnection.cancelConsumer(consumerTag);
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      // Make sure published messages are not received by the canceled consumer
-      await amqpConnection.publish(exchange, routingKey1, `testMessage-2`);
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      expect(subscriptionCallback).not.toHaveBeenCalled();
-      subscriptionCallback.mockReset();
-      // Resume the consumer
-      await amqpConnection.resumeConsumer(consumerTag);
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      // Make sure the subscription was reestablished
-      await amqpConnection.publish(exchange, routingKey1, `testMessage-3`);
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      expect(subscriptionCallback).toHaveBeenCalledWith(`testMessage-3`);
-    });
+    app = moduleFixture.createNestApplication();
+    amqpConnection = app.get<AmqpConnection>(AmqpConnection);
+    await amqpConnection.channel.assertQueue(preExistingQueue);
+    await app.init();
   });
 
-  describe('Rabbit Subscribe (Decorator)', () => {
-    beforeAll(async () => {
-      const moduleFixture = await Test.createTestingModule({
-        providers: [SubscribeService],
-        imports: [
-          RabbitMQModule.forRoot(RabbitMQModule, {
-            exchanges: [
-              {
-                name: exchange,
-                type: 'topic',
-              },
-              {
-                name: FANOUT,
-                type: FANOUT,
-              },
-            ],
-            uri,
-            connectionInitOptions: { wait: true, reject: true, timeout: 3000 },
-            logger: customLogger,
-          }),
-        ],
-      }).compile();
+  afterAll(async () => {
+    await app?.close();
+  });
 
-      app = moduleFixture.createNestApplication();
-      amqpConnection = app.get<AmqpConnection>(AmqpConnection);
-      await amqpConnection.channel.assertQueue(preExistingQueue);
-      await app.init();
-    });
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
 
-    afterAll(async () => {
-      await app?.close();
-    });
+  it('should receive subscribe messages and handle them', async () => {
+    [routingKey1, routingKey2, nonJsonRoutingKey].forEach((x, i) =>
+      amqpConnection.publish(exchange, x, `testMessage-${i}`),
+    );
 
-    beforeEach(() => {
-      jest.resetAllMocks();
-    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
-    it('should receive subscribe messages and handle them', async () => {
-      [routingKey1, routingKey2, nonJsonRoutingKey].forEach((x, i) =>
-        amqpConnection.publish(exchange, x, `testMessage-${i}`),
-      );
+    expect(testHandler).toHaveBeenCalledTimes(3);
+    expect(testHandler).toHaveBeenCalledWith(`testMessage-0`);
+    expect(testHandler).toHaveBeenCalledWith(`testMessage-1`);
+    expect(testHandler).toHaveBeenCalledWith(`testMessage-2`);
+  });
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+  it('should work with a topic exchange set up that has multiple subscribers with similar routing keys', async () => {
+    const routingKeys = [createRoutingKey, updateRoutingKey, deleteRoutingKey];
 
-      expect(testHandler).toHaveBeenCalledTimes(3);
-      expect(testHandler).toHaveBeenCalledWith(`testMessage-0`);
-      expect(testHandler).toHaveBeenCalledWith(`testMessage-1`);
-      expect(testHandler).toHaveBeenCalledWith(`testMessage-2`);
-    });
+    const promises = flatten(
+      routingKeys.map((key) => {
+        return times(100).map((x) => amqpConnection.publish(exchange, key, x));
+      }),
+    );
 
-    it('should work with a topic exchange set up that has multiple subscribers with similar routing keys', async () => {
-      const routingKeys = [
-        createRoutingKey,
-        updateRoutingKey,
-        deleteRoutingKey,
-      ];
+    await Promise.all(promises);
+    await new Promise((resolve) => setTimeout(resolve, 150));
 
-      const promises = flatten(
-        routingKeys.map((key) => {
-          return times(100).map((x) =>
-            amqpConnection.publish(exchange, key, x),
-          );
-        }),
-      );
+    expect(createHandler).toHaveBeenCalledTimes(100);
+    times(100).forEach((x) => expect(createHandler).toHaveBeenCalledWith(x));
+    expect(updateHandler).toHaveBeenCalledTimes(100);
+    times(100).forEach((x) => expect(updateHandler).toHaveBeenCalledWith(x));
+    expect(deleteHandler).toHaveBeenCalledTimes(100);
+    times(100).forEach((x) => expect(deleteHandler).toHaveBeenCalledWith(x));
+  });
 
-      await Promise.all(promises);
-      await new Promise((resolve) => setTimeout(resolve, 150));
+  it('should receive undefined argument when subscriber allows non-json messages and message is invalid', async () => {
+    amqpConnection.publish(exchange, nonJsonRoutingKey, undefined);
+    amqpConnection.publish(exchange, nonJsonRoutingKey, Buffer.alloc(0));
+    amqpConnection.publish(exchange, nonJsonRoutingKey, Buffer.from('{a:'));
 
-      expect(createHandler).toHaveBeenCalledTimes(100);
-      times(100).forEach((x) => expect(createHandler).toHaveBeenCalledWith(x));
-      expect(updateHandler).toHaveBeenCalledTimes(100);
-      times(100).forEach((x) => expect(updateHandler).toHaveBeenCalledWith(x));
-      expect(deleteHandler).toHaveBeenCalledTimes(100);
-      times(100).forEach((x) => expect(deleteHandler).toHaveBeenCalledWith(x));
-    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
-    it('should receive undefined argument when subscriber allows non-json messages and message is invalid', async () => {
-      amqpConnection.publish(exchange, nonJsonRoutingKey, undefined);
-      amqpConnection.publish(exchange, nonJsonRoutingKey, Buffer.alloc(0));
-      amqpConnection.publish(exchange, nonJsonRoutingKey, Buffer.from('{a:'));
+    expect(testHandler).toHaveBeenCalledTimes(3);
+    expect(testHandler).toHaveBeenNthCalledWith(1, undefined);
+    expect(testHandler).toHaveBeenNthCalledWith(2, undefined);
+    expect(testHandler).toHaveBeenNthCalledWith(3, undefined);
+  });
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+  it('should receive messages in existing queue without setting exchange and routing key on subscribe', async () => {
+    // publish to the default exchange, using the queue as routing key
+    const message1 = '{"key":"value 1"}';
+    const message2 = '{"key":"value 2"}';
+    const message3 = '{"key":"value 3"}';
 
-      expect(testHandler).toHaveBeenCalledTimes(3);
-      expect(testHandler).toHaveBeenNthCalledWith(1, undefined);
-      expect(testHandler).toHaveBeenNthCalledWith(2, undefined);
-      expect(testHandler).toHaveBeenNthCalledWith(3, undefined);
-    });
+    amqpConnection.publish(amqDefaultExchange, preExistingQueue, message1);
+    amqpConnection.publish(amqDefaultExchange, preExistingQueue, message2);
+    amqpConnection.publish(amqDefaultExchange, preExistingQueue, message3);
 
-    it('should receive messages in existing queue without setting exchange and routing key on subscribe', async () => {
-      // publish to the default exchange, using the queue as routing key
-      const message1 = '{"key":"value 1"}';
-      const message2 = '{"key":"value 2"}';
-      const message3 = '{"key":"value 3"}';
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
-      amqpConnection.publish(amqDefaultExchange, preExistingQueue, message1);
-      amqpConnection.publish(amqDefaultExchange, preExistingQueue, message2);
-      amqpConnection.publish(amqDefaultExchange, preExistingQueue, message3);
+    expect(testHandler).toHaveBeenCalledTimes(3);
+    expect(testHandler).toHaveBeenCalledWith(message1);
+    expect(testHandler).toHaveBeenCalledWith(message2);
+    expect(testHandler).toHaveBeenCalledWith(message3);
+  });
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+  it('should receive messages in new queue without setting exchange routing key on subscribe', async () => {
+    const message = '{"key":"value"}';
+    // publish to the default exchange, using the queue as routing key
+    amqpConnection.publish(amqDefaultExchange, nonExistingQueue, message);
 
-      expect(testHandler).toHaveBeenCalledTimes(3);
-      expect(testHandler).toHaveBeenCalledWith(message1);
-      expect(testHandler).toHaveBeenCalledWith(message2);
-      expect(testHandler).toHaveBeenCalledWith(message3);
-    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
-    it('should receive messages in new queue without setting exchange routing key on subscribe', async () => {
-      const message = '{"key":"value"}';
-      // publish to the default exchange, using the queue as routing key
-      amqpConnection.publish(amqDefaultExchange, nonExistingQueue, message);
+    expect(testHandler).toHaveBeenCalledTimes(1);
+    expect(testHandler).toHaveBeenCalledWith(message);
+  });
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+  it('should route messages to fanout exchange handlers with no routing key', async () => {
+    const message = { message: 'message' };
+    amqpConnection.publish(FANOUT, '', message);
 
-      expect(testHandler).toHaveBeenCalledTimes(1);
-      expect(testHandler).toHaveBeenCalledWith(message);
-    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
-    it('should route messages to fanout exchange handlers with no routing key', async () => {
-      const message = { message: 'message' };
-      amqpConnection.publish(FANOUT, '', message);
+    expect(fanoutHandler).toHaveBeenCalledTimes(1);
+    expect(fanoutHandler).toHaveBeenCalledWith(message);
+  });
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+  it('should go into infite lopo', async () => {
+    const message = '{"key":"value"}';
+    // tslint:disable-next-line:no-console
+    // publish and expect to acknowledge but not throw
+    const warnSpy = jest.spyOn(customLogger, 'warn');
+    amqpConnection.publish(exchange, 'infinite-loop', message);
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
-      expect(fanoutHandler).toHaveBeenCalledTimes(1);
-      expect(fanoutHandler).toHaveBeenCalledWith(message);
-    });
-
-    it('should go into infite lopo', async () => {
-      const message = '{"key":"value"}';
-      // tslint:disable-next-line:no-console
-      // publish and expect to acknowledge but not throw
-      const warnSpy = jest.spyOn(customLogger, 'warn');
-      amqpConnection.publish(exchange, 'infinite-loop', message);
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Subscribe handlers should only return void'),
-      );
-    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Subscribe handlers should only return void'),
+    );
   });
 });

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -336,19 +336,20 @@ export class AmqpConnection {
   public async createSubscriber<T>(
     handler: SubscriberHandler<T>,
     msgOptions: MessageHandlerOptions,
-    originalHandlerName: string,
-    subscriptionResultCallback?: (result: SubscriptionResult) => void
-  ) {
-    return this.selectManagedChannel(
-      msgOptions?.queueOptions?.channel
-    ).addSetup(async (channel) => {
-      const consumerTag = await this.setupSubscriberChannel<T>(
-        handler,
-        msgOptions,
-        channel,
-        originalHandlerName
+    originalHandlerName: string
+  ): Promise<SubscriptionResult> {
+    return new Promise((res) => {
+      this.selectManagedChannel(msgOptions?.queueOptions?.channel).addSetup(
+        async (channel) => {
+          const consumerTag = await this.setupSubscriberChannel<T>(
+            handler,
+            msgOptions,
+            channel,
+            originalHandlerName
+          );
+          res({ consumerTag });
+        }
       );
-      subscriptionResultCallback?.({ consumerTag });
     });
   }
 
@@ -423,18 +424,19 @@ export class AmqpConnection {
       msg: T | undefined,
       rawMessage?: ConsumeMessage
     ) => Promise<RpcResponse<U>>,
-    rpcOptions: MessageHandlerOptions,
-    subscriptionResultCallback?: (result: SubscriptionResult) => void
-  ) {
-    return this.selectManagedChannel(
-      rpcOptions?.queueOptions?.channel
-    ).addSetup(async (channel) => {
-      const consumerTag = await this.setupRpcChannel<T, U>(
-        handler,
-        rpcOptions,
-        channel
+    rpcOptions: MessageHandlerOptions
+  ): Promise<SubscriptionResult> {
+    return new Promise((res) => {
+      this.selectManagedChannel(rpcOptions?.queueOptions?.channel).addSetup(
+        async (channel) => {
+          const consumerTag = await this.setupRpcChannel<T, U>(
+            handler,
+            rpcOptions,
+            channel
+          );
+          res({ consumerTag });
+        }
       );
-      subscriptionResultCallback?.({ consumerTag });
     });
   }
 

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -50,6 +50,10 @@ export interface CorrelationMessage {
   message: Record<string, unknown>;
 }
 
+export interface SubscriptionResult {
+  consumerTag: ConsumerTag;
+}
+
 export type BaseConsumerHandler = {
   consumerTag: string;
   channel: ConfirmChannel;
@@ -333,7 +337,7 @@ export class AmqpConnection {
     handler: SubscriberHandler<T>,
     msgOptions: MessageHandlerOptions,
     originalHandlerName: string,
-    consumerTagCallback?: (tag: ConsumerTag) => void
+    subscriptionResultCallback?: (result: SubscriptionResult) => void
   ) {
     return this.selectManagedChannel(
       msgOptions?.queueOptions?.channel
@@ -344,7 +348,7 @@ export class AmqpConnection {
         channel,
         originalHandlerName
       );
-      consumerTagCallback?.(consumerTag);
+      subscriptionResultCallback?.({ consumerTag });
     });
   }
 
@@ -420,7 +424,7 @@ export class AmqpConnection {
       rawMessage?: ConsumeMessage
     ) => Promise<RpcResponse<U>>,
     rpcOptions: MessageHandlerOptions,
-    consumerTagCallback?: (tag: ConsumerTag) => void
+    subscriptionResultCallback?: (result: SubscriptionResult) => void
   ) {
     return this.selectManagedChannel(
       rpcOptions?.queueOptions?.channel
@@ -430,7 +434,7 @@ export class AmqpConnection {
         rpcOptions,
         channel
       );
-      consumerTagCallback?.(consumerTag);
+      subscriptionResultCallback?.({ consumerTag });
     });
   }
 


### PR DESCRIPTION
This will enable the `ConsumerTag` to be subsequently passed to the `cancelConsumer()` and `resumeConsumer()` methods on the `AmqpConnection` class.