### PR TITLE
fix(rabbitmq): properly close the AMQP connections on application shutdown

### DIFF
--- a/packages/rabbitmq/src/rabbitmq.module.ts
+++ b/packages/rabbitmq/src/rabbitmq.module.ts
@@ -127,7 +127,7 @@ export class RabbitMQModule
     await Promise.all(
       this.connectionManager
         .getConnections()
-        .map((connection) => connection.managedConnection.close)
+        .map((connection) => connection.managedConnection.close())
     );
   }
 


### PR DESCRIPTION
Rather than returning a Promise from our map() callback, we were returning the function to be
called.

fix #482