### PR TITLE
feat(rabbitmq): add generic type to publish for simple type checking

### DIFF
--- a/packages/rabbitmq/README.md
+++ b/packages/rabbitmq/README.md
@@ -1,4 +1,3 @@
-
 # @golevelup/nestjs-rabbitmq
 
 <p align="center">
@@ -228,7 +227,6 @@ interceptedRpc() {
 }
 ```
 
-
 ```typescript
 @RabbitRPC({
   routingKey: 'intercepted-rpc-2',
@@ -412,10 +410,10 @@ export class AppController {
 If you just want to publish a message onto a RabbitMQ exchange, use the `publish` method of the `AmqpConnection` which has the following signature:
 
 ```typescript
-public publish(
+public publish<T = any>(
   exchange: string,
   routingKey: string,
-  message: any,
+  message: T,
   options?: amqplib.Options.Publish
 )
 ```
@@ -424,6 +422,14 @@ For example:
 
 ```typescript
 amqpConnection.publish('some-exchange', 'routing-key', { msg: 'hello world' });
+
+// optionally specify a type for generic type checking support
+interface CustomModel {
+  foo: string;
+  bar: string;
+}
+amqpConnection.publish<CustomModel>('some-exchange', 'routing-key', {});
+// this will now show an error that you are missing properties: foo, bar
 ```
 
 ### Requesting Data from an RPC

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -513,10 +513,10 @@ export class AmqpConnection {
     return consumerTag;
   }
 
-  public publish(
+  public publish<T = any>(
     exchange: string,
     routingKey: string,
-    message: any,
+    message: T,
     options?: Options.Publish
   ) {
     // source amqplib channel is used directly to keep the behavior of throwing connection related errors


### PR DESCRIPTION
This change provides a way to have basic type checking done when publishing messages. 
By default it still uses the generic type any. `public publish<T = any>(` so no changes are needed for existing code.

Simple example of the benefit at development stage.
![image](https://user-images.githubusercontent.com/2848788/183069383-aacc2f3b-70cd-468e-b882-fcef35d458de.png)
