### PR TITLE
Cleanup connections and bootstrapped = false on application shutdown

### DIFF
--- a/packages/rabbitmq/src/amqp/connectionManager.ts
+++ b/packages/rabbitmq/src/amqp/connectionManager.ts
@@ -16,4 +16,8 @@ export class AmqpConnectionManager {
   getConnections() {
     return this.connections;
   }
+
+  clearConnections() {
+    this.connections = [];
+  }
 }

--- a/packages/rabbitmq/src/rabbitmq.module.ts
+++ b/packages/rabbitmq/src/rabbitmq.module.ts
@@ -130,6 +130,7 @@ export class RabbitMQModule
         .map((connection) => connection.managedConnection.close())
     );
 
+    this.connectionManager.clearConnections();
     RabbitMQModule.bootstrapped = false;
   }
 

--- a/packages/rabbitmq/src/rabbitmq.module.ts
+++ b/packages/rabbitmq/src/rabbitmq.module.ts
@@ -129,6 +129,8 @@ export class RabbitMQModule
         .getConnections()
         .map((connection) => connection.managedConnection.close())
     );
+
+    RabbitMQModule.bootstrapped = false;
   }
 
   // eslint-disable-next-line sonarjs/cognitive-complexity


### PR DESCRIPTION
Allow module to be reinitialized. Usefull in e2e mocha tests.