### PR TITLE
Ensure Promise Resolution in createSubscriber

### DIFF
--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -343,6 +343,7 @@ export class AmqpConnection {
     originalHandlerName: string
   ): Promise<SubscriptionResult> {
     return new Promise((res) => {
+      let result: SubscriptionResult;
       this.selectManagedChannel(msgOptions?.queueOptions?.channel)
         .addSetup(async (channel) => {
           const consumerTag = await this.setupSubscriberChannel<T>(
@@ -351,9 +352,9 @@ export class AmqpConnection {
             channel,
             originalHandlerName
           );
-          res({ consumerTag });
+          result = { consumerTag };
         })
-        .then((result: any) => {
+        .then(() => {
           res(result);
         });
     });

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -343,8 +343,8 @@ export class AmqpConnection {
     originalHandlerName: string
   ): Promise<SubscriptionResult> {
     return new Promise((res) => {
-      this.selectManagedChannel(msgOptions?.queueOptions?.channel).addSetup(
-        async (channel) => {
+      this.selectManagedChannel(msgOptions?.queueOptions?.channel)
+        .addSetup(async (channel) => {
           const consumerTag = await this.setupSubscriberChannel<T>(
             handler,
             msgOptions,
@@ -352,8 +352,10 @@ export class AmqpConnection {
             originalHandlerName
           );
           res({ consumerTag });
-        }
-      );
+        })
+        .then((result: any) => {
+          res(result);
+        });
     });
   }
 


### PR DESCRIPTION
The resolution callback was not invoked when the channel could not be created on application startup.

The solution is to resolve the `Promise` in a `then` handler. Since all of the `Promise`s involved are `Promise<void>`, this is done by setting a local variable.

The `addSetup` function is called without specifying any done parameter. Then, `addSetup` returns the result of calling `pb.addCallback` without any `done` parameter. According to the documentation of `pb.addCallback`, this simply returns the supplied `Promise`, namely, this `Promise` (let's call it "Promise A"):

```typescript
(this._settingUp || Promise.resolve()).then(() => {
                this._setups.push(setup);
                if (this._channel) {
                    return pb.call(setup, this, this._channel);
                } else {
                    return undefined;
                }
            })
```

Promise A proceeds as follows: first, Promise A waits for the `Promise` `(this._settingUp || Promise.resolve())` to resolve, next the `then` handler is called, and finally Promise A resolves.

Now, when the then handler is called, the setup callback will be called if and only if `this._channel` is defined. However, in all cases, Promise A resolves to `undefined` (at least at the type level, i.e. assuming that the setup callback really is a `void` callback). If the `then` handler invokes return `pb.call`, it will wait for the `Promise` returned from `pb.call` to resolve to a value, and then resolve to the same value (which should be `undefined` since the setup callback is supposed to be a `void` function). If the `then` handler immediately returns `undefined`, then Promise A resolves immediately - but regardless, it resolves to `undefined`; the only difference is whether or not the `setup` callback is invoked. Either way, when it is done, it resolves to `undefined`.

When Promise A is finished, the final `then` handler is called. If the `setup` callback was invoked, a value will be set in the `result` variable. Otherwise, `result` will be `undefined`.

We can then resolve with `res(result)`. I wonder if an `error` handler is needed to reject the `Promise` or if errors cannot occur for some reason.