### PR TITLE
feat(rabbitmq): add the option to avoid declaring exchanges

### DIFF
--- a/integration/rabbitmq/e2e/configuration.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/configuration.e2e-spec.ts
@@ -1,4 +1,8 @@
-import { RabbitMQConfig, RabbitMQModule } from '@golevelup/nestjs-rabbitmq';
+import {
+  RabbitMQConfig,
+  AmqpConnection,
+  RabbitMQModule,
+} from '@golevelup/nestjs-rabbitmq';
 import { ConsoleLogger } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as amqplib from 'amqplib';
@@ -10,6 +14,8 @@ const rabbitPort =
 const uri = `amqp://rabbitmq:rabbitmq@${rabbitHost}:${rabbitPort}`;
 const amqplibUri = `${uri}?heartbeat=5`;
 const logger = new ConsoleLogger('Custom logger');
+
+const nonExistingExchange = 'non-existing-exchange';
 
 class RabbitConfig {
   createModuleConfig(): RabbitMQConfig {
@@ -50,6 +56,111 @@ describe('Module Configuration', () => {
       expect(spy).toHaveBeenCalledWith(amqplibUri, undefined);
 
       expect(logSpy).toHaveBeenCalled();
+    });
+
+    describe('should use `createExchangeIfNotExists` flag correctly', () => {
+      it("should throw an error if exchange doesn't exist and `createExchangeIfNotExists` is false", async () => {
+        try {
+          app = await Test.createTestingModule({
+            imports: [
+              RabbitMQModule.forRoot(RabbitMQModule, {
+                exchanges: [
+                  {
+                    name: nonExistingExchange,
+                    type: 'topic',
+                    createExchangeIfNotExists: false,
+                  },
+                ],
+                uri,
+                connectionInitOptions: {
+                  wait: true,
+                  reject: true,
+                  timeout: 3000,
+                },
+                logger,
+              }),
+            ],
+          }).compile();
+
+          fail(
+            `Exchange "${nonExistingExchange}" should not exist before running this test`,
+          );
+        } catch (error) {
+          expect(error).toBeDefined();
+        }
+      });
+
+      it('should create an exchange successfully if `createExchangeIfNotExists` is true', async () => {
+        const spy = jest.spyOn(amqplib, 'connect');
+        // const logSpy = jest.spyOn(logger, 'log');
+
+        app = await Test.createTestingModule({
+          imports: [
+            RabbitMQModule.forRoot(RabbitMQModule, {
+              exchanges: [
+                {
+                  name: nonExistingExchange,
+                  type: 'topic',
+                  createExchangeIfNotExists: true,
+                },
+              ],
+              uri,
+              connectionInitOptions: {
+                wait: true,
+                reject: true,
+                timeout: 3000,
+              },
+              logger,
+            }),
+          ],
+        }).compile();
+
+        const amqpConnection = app.get<AmqpConnection>(AmqpConnection);
+        expect(app).toBeDefined();
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(amqplibUri, undefined);
+
+        await app.init();
+        expect(
+          await amqpConnection.channel.checkExchange(nonExistingExchange),
+        ).toBeDefined();
+        await app.close();
+      });
+
+      it('should connect to an existing exchange successfully if `createExchangeIfNotExists` is false', async () => {
+        const spy = jest.spyOn(amqplib, 'connect');
+
+        app = await Test.createTestingModule({
+          imports: [
+            RabbitMQModule.forRoot(RabbitMQModule, {
+              exchanges: [
+                {
+                  name: nonExistingExchange,
+                  type: 'topic',
+                  createExchangeIfNotExists: false,
+                },
+              ],
+              uri,
+              connectionInitOptions: {
+                wait: true,
+                reject: true,
+                timeout: 3000,
+              },
+              logger,
+            }),
+          ],
+        }).compile();
+
+        const amqpConnection = app.get<AmqpConnection>(AmqpConnection);
+        expect(app).toBeDefined();
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(amqplibUri, undefined);
+
+        // Clear non-existing exchange
+        await amqpConnection.channel.deleteExchange(nonExistingExchange);
+      });
     });
   });
 
@@ -138,6 +249,120 @@ describe('Module Configuration', () => {
 
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith(amqplibUri, undefined);
+    });
+
+    describe('should use `createExchangeIfNotExists` flag correctly', () => {
+      it("should throw an error if exchange doesn't exist and `createExchangeIfNotExists` is false", async () => {
+        try {
+          app = await Test.createTestingModule({
+            imports: [
+              RabbitMQModule.forRootAsync(RabbitMQModule, {
+                useFactory: async () => {
+                  return {
+                    exchanges: [
+                      {
+                        name: nonExistingExchange,
+                        type: 'topic',
+                        createExchangeIfNotExists: false,
+                      },
+                    ],
+                    uri,
+                    connectionInitOptions: {
+                      wait: true,
+                      reject: true,
+                      timeout: 3000,
+                    },
+                  };
+                },
+              }),
+            ],
+          }).compile();
+
+          fail(
+            `Exchange "${nonExistingExchange}" should not exist before running this test`,
+          );
+        } catch (error) {
+          expect(error).toBeDefined();
+        }
+      });
+
+      it('should create an exchange successfully if `createExchangeIfNotExists` is true', async () => {
+        const spy = jest.spyOn(amqplib, 'connect');
+
+        app = await Test.createTestingModule({
+          imports: [
+            RabbitMQModule.forRootAsync(RabbitMQModule, {
+              useFactory: async () => {
+                return {
+                  exchanges: [
+                    {
+                      name: nonExistingExchange,
+                      type: 'topic',
+                      createExchangeIfNotExists: true,
+                    },
+                  ],
+                  uri,
+                  connectionInitOptions: {
+                    wait: true,
+                    reject: true,
+                    timeout: 3000,
+                  },
+                };
+              },
+            }),
+          ],
+        }).compile();
+
+        const amqpConnection = app.get<AmqpConnection>(AmqpConnection);
+        expect(app).toBeDefined();
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(amqplibUri, undefined);
+
+        await app.init();
+        expect(
+          await amqpConnection.channel.checkExchange(nonExistingExchange),
+        ).toBeDefined();
+        await app.close();
+      });
+
+      it('should connect to an existing exchange successfully if `createExchangeIfNotExists` is false', async () => {
+        const spy = jest.spyOn(amqplib, 'connect');
+
+        app = await Test.createTestingModule({
+          imports: [
+            RabbitMQModule.forRootAsync(RabbitMQModule, {
+              // eslint-disable-next-line
+              useFactory: async () => {
+                return {
+                  exchanges: [
+                    {
+                      name: nonExistingExchange,
+                      type: 'topic',
+                      createExchangeIfNotExists: true,
+                    },
+                  ],
+                  uri,
+                  connectionInitOptions: {
+                    wait: true,
+                    reject: true,
+                    timeout: 3000,
+                  },
+                };
+              },
+            }),
+          ],
+        }).compile();
+
+        const amqpConnection = app.get<AmqpConnection>(AmqpConnection);
+        expect(app).toBeDefined();
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(amqplibUri, undefined);
+
+        // Clear non-existing exchange
+        await amqpConnection.channel.deleteExchange(nonExistingExchange);
+      });
     });
   });
 });

--- a/integration/rabbitmq/e2e/configuration.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/configuration.e2e-spec.ts
@@ -92,7 +92,6 @@ describe('Module Configuration', () => {
 
       it('should create an exchange successfully if `createExchangeIfNotExists` is true', async () => {
         const spy = jest.spyOn(amqplib, 'connect');
-        // const logSpy = jest.spyOn(logger, 'log');
 
         app = await Test.createTestingModule({
           imports: [

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -263,13 +263,21 @@ export class AmqpConnection {
       this._channel = channel;
 
       // Always assert exchanges & rpc queue in default channel.
-      this.config.exchanges.forEach((x) =>
-        channel.assertExchange(
+      this.config.exchanges.forEach((x) => {
+        if (x.createExchangeIfNotExists) {
+            return channel.assertExchange(
+              x.name,
+              x.type || this.config.defaultExchangeType,
+              x.options
+            )
+        }
+        return channel.checkExchange(
           x.name,
           x.type || this.config.defaultExchangeType,
           x.options
         )
-      );
+      });
+
 
       if (this.config.enableDirectReplyTo) {
         await this.initDirectReplyQueue(channel);

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -264,7 +264,9 @@ export class AmqpConnection {
 
       // Always assert exchanges & rpc queue in default channel.
       this.config.exchanges.forEach((x) => {
-        if (x.createExchangeIfNotExists) {
+        const { createExchangeIfNotExists = true } = x;
+
+        if (createExchangeIfNotExists) {
           return channel.assertExchange(
             x.name,
             x.type || this.config.defaultExchangeType,

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -265,19 +265,14 @@ export class AmqpConnection {
       // Always assert exchanges & rpc queue in default channel.
       this.config.exchanges.forEach((x) => {
         if (x.createExchangeIfNotExists) {
-            return channel.assertExchange(
-              x.name,
-              x.type || this.config.defaultExchangeType,
-              x.options
-            )
+          return channel.assertExchange(
+            x.name,
+            x.type || this.config.defaultExchangeType,
+            x.options
+          );
         }
-        return channel.checkExchange(
-          x.name,
-          x.type || this.config.defaultExchangeType,
-          x.options
-        )
+        return channel.checkExchange(x.name);
       });
-
 
       if (this.config.enableDirectReplyTo) {
         await this.initDirectReplyQueue(channel);

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -10,6 +10,7 @@ import {
 export interface RabbitMQExchangeConfig {
   name: string;
   type?: string;
+  createExchangeIfNotExists?: boolean;
   options?: Options.AssertExchange;
 }
 


### PR DESCRIPTION
It is entirely possible for a rabbitmq user to not have rights to declare an exchange, and just consume it instead. This is the motivation of this PR: I couldn't find any option in the current state of the package that allows me to do this (only patching!).

Implementation is fairly simple: if I set the exchange creation flag to `false`, I should only check for its existence.

This is crucial for the project I'm working on, so I'd really appreciate if this is added as a feature. If it's not, I can always continue to patch, but this needs to happen on my side :)