### PR TITLE
fix(ts-jest): unknown property in deep typings issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,12 @@ name: Continuous Integration
 
 on: pull_request
 
-concurrency: 
+concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true
 
 env:
-  LATEST_NODE_VERSION: 17
+  LATEST_NODE_VERSION: 18
 
 jobs:
   ci:
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [14, 16, 17]
+        node: [14, 16, 18, 19]
       fail-fast: false
 
     services:

--- a/packages/testing/src/mocks.spec.ts
+++ b/packages/testing/src/mocks.spec.ts
@@ -123,6 +123,25 @@ describe('Mocks', () => {
       expect(result).toBe(42);
       expect(mock.doSomethingAsync).toBeCalledTimes(1);
     });
+
+    it('should work with unknown properties', () => {
+      class Base {
+        field?: unknown;
+      }
+
+      class Test {
+        get base(): Base {
+          return undefined as any;
+        }
+      }
+
+      const base = createMock<Base>();
+      const test = createMock<Test>({
+        base,
+      });
+
+      expect(test.base).toEqual(base);
+    });
   });
 
   describe('auto mocked', () => {

--- a/packages/testing/src/mocks.ts
+++ b/packages/testing/src/mocks.ts
@@ -3,7 +3,7 @@ type DeepPartial<T> = {
     ? Array<DeepPartial<U>>
     : T[P] extends ReadonlyArray<infer U>
     ? ReadonlyArray<DeepPartial<U>>
-    : DeepPartial<T[P]>;
+    : (unknown extends T[P] ? T[P] : DeepPartial<T[P]>);
 };
 
 export type PartialFuncReturn<T> = {


### PR DESCRIPTION
The `DeepPartial` type doesn't handle unknown types properly.

Given
```ts
      class Base {
        field?: unknown;
      }

      class Test {
        get base(): Base {
          return undefined as any;
        }
      }

      const base = createMock<Base>();
      const test = createMock<Test>({
        base,
      });
```
You receive the following error:
```
error TS2322: Type 'DeepMocked<Base>' is not assignable to type 'DeepPartial<Base> | undefined'.
      Type 'DeepMocked<Base>' is not assignable to type 'DeepPartial<Base>'.
        Types of property 'field' are incompatible.
          Type 'unknown' is not assignable to type 'DeepPartial<unknown> | undefined'.
```

The fix is easy - stop the recursion when `unknown` type is encountered.

This PR adds the reproducible test and the simple fix.