### PR TITLE
feat(module): allow to configure two secrets for different stripe webhooks types(account & connect)

### DIFF
--- a/packages/stripe/README.md
+++ b/packages/stripe/README.md
@@ -38,7 +38,11 @@ Interacting with the Stripe API or consuming Stripe webhooks in your NestJS appl
 
 ### Import
 
-Import and add `StripeModule` to the `imports` section of the consuming module (most likely `AppModule`). Your Stripe API key is required, and you can optionally include a webhook configuration if you plan on consuming Stripe webhook events inside your app.
+Import and add `StripeModule` to the `imports` section of the consuming module (most likely `AppModule`). Your Stripe API key is required, and you can optionally include a webhook configuration if you plan on consuming Stripe webhook events inside your app.  
+Stripe secrets you can get from your Dashboard’s [Webhooks settings](https://dashboard.stripe.com/webhooks). Select an endpoint that you want to obtain the secret for, then click the Click to reveal button.
+
+`account` - The webhook secret registered in the Stripe Dashboard for events on your accounts  
+`connect` - The webhook secret registered in the Stripe Dashboard for events on Connected accounts
 
 ```typescript
 import { StripeModule } from '@golevelup/nestjs-stripe';
@@ -48,7 +52,10 @@ import { StripeModule } from '@golevelup/nestjs-stripe';
     StripeModule.forRoot(StripeModule, {
       apiKey: '123',
       webhookConfig: {
-        stripeWebhookSecret: 'abc',
+        stripeSecrets: {
+          account: 'abc',
+          connect: 'cba',
+        },
       },
     }),
   ],

--- a/packages/stripe/src/stripe.interfaces.ts
+++ b/packages/stripe/src/stripe.interfaces.ts
@@ -1,15 +1,32 @@
 import Stripe from 'stripe';
 
+type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<
+  T,
+  Exclude<keyof T, Keys>
+> &
+  {
+    [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
+  }[Keys];
+
+interface StripeSecrets {
+  /**
+   * The webhook secret registered in the Stripe Dashboard for events on your accounts
+   */
+  account?: string;
+
+  /**
+   * The webhook secret registered in the Stripe Dashboard for events on Connected accounts
+   */
+  connect?: string;
+}
+
 export interface StripeModuleConfig extends Partial<Stripe.StripeConfig> {
   readonly apiKey: string;
   /**
    * Configuration for processing Stripe Webhooks
    */
   webhookConfig?: {
-    /**
-     * The webhook secret registered in the Stripe Dashboard
-     */
-    stripeWebhookSecret: string;
+    stripeSecrets: RequireAtLeastOne<StripeSecrets>;
 
     /**
      * The property on the request that contains the raw message body so that it

--- a/packages/stripe/src/stripe.module.ts
+++ b/packages/stripe/src/stripe.module.ts
@@ -86,10 +86,12 @@ export class StripeModule
       return;
     }
 
-    if (
+    const noOneSecretProvided =
       this.stripeModuleConfig.webhookConfig &&
-      !this.stripeModuleConfig.webhookConfig?.stripeWebhookSecret
-    ) {
+      !this.stripeModuleConfig.webhookConfig?.stripeSecrets.account &&
+      !this.stripeModuleConfig.webhookConfig?.stripeSecrets.connect;
+
+    if (noOneSecretProvided) {
       const errorMessage =
         'missing stripe webhook secret. module is improperly configured and will be unable to process incoming webhooks from Stripe';
       this.logger.error(errorMessage);

--- a/packages/stripe/src/stripe.payload.service.ts
+++ b/packages/stripe/src/stripe.payload.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { Buffer } from 'node:buffer';
 import Stripe from 'stripe';
 import {
   InjectStripeClient,
@@ -9,6 +10,7 @@ import { StripeModuleConfig } from './stripe.interfaces';
 @Injectable()
 export class StripePayloadService {
   private readonly stripeWebhookSecret: string;
+  private readonly stripeConnectWebhookSecret: string;
 
   constructor(
     @InjectStripeModuleConfig()
@@ -17,13 +19,21 @@ export class StripePayloadService {
     private readonly stripeClient: Stripe
   ) {
     this.stripeWebhookSecret =
-      this.config.webhookConfig?.stripeWebhookSecret || '';
+      this.config.webhookConfig?.stripeSecrets.account || '';
+    this.stripeConnectWebhookSecret =
+      this.config.webhookConfig?.stripeSecrets.connect || '';
   }
   tryHydratePayload(signature: string, payload: Buffer): { type: string } {
+    const decodedPayload = JSON.parse(
+      Buffer.isBuffer(payload) ? payload.toString('utf8') : payload
+    );
+
     return this.stripeClient.webhooks.constructEvent(
       payload,
       signature,
-      this.stripeWebhookSecret
+      decodedPayload.account
+        ? this.stripeConnectWebhookSecret
+        : this.stripeWebhookSecret
     );
   }
 }

--- a/packages/stripe/src/tests/stripe.module.spec.ts
+++ b/packages/stripe/src/tests/stripe.module.spec.ts
@@ -45,7 +45,9 @@ describe('Stripe Module', () => {
         StripeModule.forRoot(StripeModule, {
           apiKey: '123',
           webhookConfig: {
-            stripeWebhookSecret: 'super-secret',
+            stripeSecrets: {
+              account: 'super-secret',
+            },
             decorators: [TestDecorator()],
           },
         }),

--- a/packages/stripe/src/tests/stripe.webhook.e2e.spec.ts
+++ b/packages/stripe/src/tests/stripe.webhook.e2e.spec.ts
@@ -51,7 +51,9 @@ describe.each(cases)(
     const moduleConfig: StripeModuleConfig = {
       apiKey: '123',
       webhookConfig: {
-        stripeWebhookSecret: '123',
+        stripeSecrets: {
+          account: '123',
+        },
         loggingConfiguration: {
           logMatchingEventHandlers: true,
         },


### PR DESCRIPTION
BREAKING CHANGE: Stripe module `webhookConfig`

closes #355 