### PR TITLE
fix: issue with scheduled events without a comment

### DIFF
--- a/packages/hasura/src/hasura.module.ts
+++ b/packages/hasura/src/hasura.module.ts
@@ -172,7 +172,7 @@ export class HasuraModule
     ) => {
       const keys = isHasuraEvent(evt)
         ? [evt.trigger?.name, `${evt?.table?.schema}-${evt?.table?.name}`]
-        : isHasuraScheduledEventPayload(evt) && evt.comment
+        : isHasuraScheduledEventPayload(evt)
           ? [evt.name || evt.comment]
           : [evt.id];
       if (!keys) throw new Error('Not a Hasura Event');


### PR DESCRIPTION
I recently noticed that Scheduled Events were not being processed anymore, we encountered errors like this: 

```bash
Handler not found for 94605691-b97a-47f2-b03e-3368d4de16bc - {"stack":["HasuraModule"]}
```

Turns out, 3 months ago, this line was introduced, which will try to use the `id` of the event instead of the name, unless a comment has been specified on the event definition: 

https://github.com/golevelup/nestjs/blob/master/packages/hasura/src/hasura.module.ts#L175

I suggest we remove this condition to avoid having to set a comment on scheduled events.

