### PR TITLE
docs(testing): updated ts-jest install docs

### DIFF
--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -27,13 +27,13 @@ For examples we'll show how well it works with NestJS' [ExecutionContext](https:
 Pretty standard installation, nothing too crazy
 
 ```sh
-npm i @golevelup/ts-jest
+npm i @golevelup/ts-jest --save-dev
 ```
 
 or
 
 ```sh
-yarn add @golevelup/ts-jest
+yarn add @golevelup/ts-jest --dev
 ```
 
 ### Creating Mocks


### PR DESCRIPTION
 Updated ts-jest install docs so that is added as a devDependency,

Testing libraries do not need to be added in a production environment. Good to, by default, recommend splitting dev/production dependencies.