### PR TITLE
fix(graphql-request): Exporting GraphQLRequestModuleConfig interface

### DIFF
--- a/packages/graphql-request/src/graphql-request.module.ts
+++ b/packages/graphql-request/src/graphql-request.module.ts
@@ -3,14 +3,14 @@ import { Module } from '@nestjs/common';
 import { GraphQLClient } from 'graphql-request';
 import {
   GraphQLClientConfigInject,
-  GraphQLClientInject,
+  GraphQLClientInject
 } from './graphql-request.constants';
 
 type GraphQLClientConstructorParams = ConstructorParameters<
   typeof GraphQLClient
 >;
 
-interface GraphQLRequestModuleConfig {
+export interface GraphQLRequestModuleConfig {
   endpoint: GraphQLClientConstructorParams[0];
   options?: GraphQLClientConstructorParams[1];
 }


### PR DESCRIPTION
Exporting GraphQLRequestModuleConfig interface to be able to use it when creating config classes like so:

```typescript
...
imports: [
        ConfigModule.forFeature(corePdfClientConfig),
        GraphQLRequestModule.forRootAsync(GraphQLRequestModule, {
            useClass: CorePdfClientConfig,
            imports: [M2MAuthModule],
        }),
    ],

...

export class CorePdfClientConfig implements ModuleConfigFactory<GraphQLRequestModuleConfig> {

```

