### PR TITLE
ci: drop support for node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [14, 16, 18, 19]
+        node: [16, 18, 19]
       fail-fast: false
 
     services:


### PR DESCRIPTION
Drops support for node 14 as it will be out of support on 30 April 2023
We should advise our users to use at least the `LTS` version

## Resources
https://azure.microsoft.com/en-us/updates/community-support-for-node-14-lts-is-ending-on-30-april-2023/
https://nodejs.dev/en/about/releases/