### PR TITLE
fix(ts-jest): missing jest when injectGlobals=false

### DIFF
--- a/packages/testing/src/mocks.ts
+++ b/packages/testing/src/mocks.ts
@@ -1,3 +1,5 @@
+import { jest } from '@jest/globals';
+
 type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends Array<infer U>
     ? Array<DeepPartial<U>>


### PR DESCRIPTION
Should fix: https://github.com/golevelup/nestjs/issues/557#event-8587363528