### PR TITLE
fixed the order of generated metadata

### DIFF
--- a/packages/hasura/src/hasura-metadata-dist/HasuraMetadataV2.js
+++ b/packages/hasura/src/hasura-metadata-dist/HasuraMetadataV2.js
@@ -714,8 +714,8 @@ const typeMap = {
         { json: "webhook", js: "webhook", typ: "" },
     ], "any"),
     "RetryConfST": o([
-        { json: "num_retries", js: "num_retries", typ: u(undefined, 0) },
         { json: "retry_interval_seconds", js: "retry_interval_seconds", typ: u(undefined, 0) },
+        { json: "num_retries", js: "num_retries", typ: u(undefined, 0) },
         { json: "timeout_seconds", js: "timeout_seconds", typ: u(undefined, 0) },
         { json: "tolerance_seconds", js: "tolerance_seconds", typ: u(undefined, 0) },
     ], "any"),


### PR DESCRIPTION
### Description:
This package creates the metadata for events like this:
```yaml
num_retries: 3
interval_sec: 15
```

But when you export the metadata from hasura, the order is different:
```yaml
interval_sec: 15
num_retries: 3
```
This means you have to commit those changes every time if the order of exporting and generating metadata is not consistent. For example, if I change something in hasura and export the metadata and commit those changes, the next time I change my code, the order of the generated metadata will change and I have to commit those files again.

The manual solution is to make sure the order of generating/exporting metadata is the same, but that's annoying when you can fix this by changing one line of code.