### PR TITLE
fix(discovery.service.ts): uses better truth check with lodash isNil

### DIFF
--- a/packages/discovery/src/discovery.service.ts
+++ b/packages/discovery/src/discovery.service.ts
@@ -5,7 +5,7 @@ import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { Module } from '@nestjs/core/injector/module';
 import { ModulesContainer } from '@nestjs/core/injector/modules-container';
 import { MetadataScanner } from '@nestjs/core/metadata-scanner';
-import { flatMap, get, some, uniqBy } from 'lodash';
+import { flatMap, get, isNil, some, uniqBy } from 'lodash';
 import {
   DiscoveredClass,
   DiscoveredClassWithMeta,
@@ -172,7 +172,7 @@ export class DiscoveryService {
       .scanFromPrototype(instance, prototype, (name) =>
         this.extractMethodMetaAtKey<T>(metaKey, component, prototype, name)
       )
-      .filter((x) => !!x.meta);
+      .filter((x) => !isNil(x.meta));
   }
 
   /**


### PR DESCRIPTION
using lodash isNil avoids false positives when checking for meta

closes #595