### PR TITLE
feat(connection.ts): support service property to read consumer tags

### DIFF
--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -323,7 +323,7 @@ export class AmqpConnection {
       map((x) => x.message as T),
       first()
     );
-    
+
     const timeout$ = interval(timeout).pipe(
       first(),
       map(() => {
@@ -721,6 +721,10 @@ export class AmqpConnection {
 
   private getConsumer(consumerTag: ConsumerTag) {
     return this._consumers[consumerTag];
+  }
+
+  get consumerTags(): string[] {
+    return Object.keys(this._consumers);
   }
 
   public async cancelConsumer(consumerTag: ConsumerTag) {


### PR DESCRIPTION
Exposes a new "get" method for consumer tags

Closes #596