### PR TITLE
feat(rabbitmq): replace defaultRpcErrorBehavior with defaultRpcErrorHandler

### DIFF
--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -86,7 +86,9 @@ const defaultConfig = {
   name: 'default',
   prefetchCount: 10,
   defaultExchangeType: 'topic',
-  defaultRpcErrorBehavior: MessageHandlerErrorBehavior.REQUEUE,
+  defaultRpcErrorHandler: getHandlerForLegacyBehavior(
+    MessageHandlerErrorBehavior.REQUEUE
+  ),
   defaultSubscribeErrorBehavior: MessageHandlerErrorBehavior.REQUEUE,
   exchanges: [],
   defaultRpcTimeout: 10000,
@@ -521,6 +523,7 @@ export class AmqpConnection {
           } else {
             const errorHandler =
               rpcOptions.errorHandler ||
+              this.config.defaultRpcErrorHandler ||
               getHandlerForLegacyBehavior(
                 rpcOptions.errorBehavior ||
                   this.config.defaultSubscribeErrorBehavior

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -100,7 +100,7 @@ export interface RabbitMQConfig {
   exchanges?: RabbitMQExchangeConfig[];
   defaultRpcTimeout?: number;
   defaultExchangeType?: string;
-  defaultRpcErrorBehavior?: MessageHandlerErrorBehavior;
+  defaultRpcErrorHandler?: MessageErrorHandler;
   defaultSubscribeErrorBehavior?: MessageHandlerErrorBehavior;
   connectionInitOptions?: ConnectionInitOptions;
   connectionManagerOptions?: AmqpConnectionManagerOptions;


### PR DESCRIPTION
This merge request replaces the `defaultRpcErrorBehavior` property with the `defaultRpcErrorHandler` property within `RabbitMQConfig`.

This makes it possible to use the same custom ErrorHandler for all RabbitRPC decorators. Currently, the global definition is limited to `ACK`, `NACK` and `REQUEUE`.

The old behaviour still exists because `getHandlerForLegacyBehavior(MessageHandlerErrorBehavior.REQUEUE)` is used as the default value.