### PR TITLE
fix(rabbitmq): using `__routeArguments__` key to allow pipe injection

### DIFF
--- a/packages/rabbitmq/src/rabbitmq.constants.ts
+++ b/packages/rabbitmq/src/rabbitmq.constants.ts
@@ -1,6 +1,5 @@
 export const RABBIT_HANDLER = Symbol('RABBIT_HANDLER');
 export const RABBIT_CONFIG_TOKEN = Symbol('RABBIT_CONFIG');
-export const RABBIT_ARGS_METADATA = 'RABBIT_ARGS_METADATA';
 export const RABBIT_PARAM_TYPE = 3;
 export const RABBIT_HEADER_TYPE = 4;
 export const RABBIT_REQUEST_TYPE = 5;

--- a/packages/rabbitmq/src/rabbitmq.decorators.ts
+++ b/packages/rabbitmq/src/rabbitmq.decorators.ts
@@ -7,9 +7,9 @@ import {
   Type,
   assignMetadata,
 } from '@nestjs/common';
+import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
 import { isString } from 'lodash';
 import {
-  RABBIT_ARGS_METADATA,
   RABBIT_CONFIG_TOKEN,
   RABBIT_HANDLER,
   RABBIT_HEADER_TYPE,
@@ -47,14 +47,14 @@ export const createPipesRpcParamDecorator =
   ): ParameterDecorator =>
   (target, key, index) => {
     const args =
-      Reflect.getMetadata(RABBIT_ARGS_METADATA, target.constructor, key) || {};
+      Reflect.getMetadata(ROUTE_ARGS_METADATA, target.constructor, key) || {};
 
     const hasParamData = isString(data);
     const paramData = hasParamData ? data : undefined;
     const paramPipes = hasParamData ? pipes : [data, ...pipes];
 
     Reflect.defineMetadata(
-      RABBIT_ARGS_METADATA,
+      ROUTE_ARGS_METADATA,
       assignMetadata(args, type, index, paramData, ...paramPipes),
       target.constructor,
       key

--- a/packages/rabbitmq/src/rabbitmq.module.ts
+++ b/packages/rabbitmq/src/rabbitmq.module.ts
@@ -10,15 +10,12 @@ import {
   OnApplicationBootstrap,
   OnApplicationShutdown,
 } from '@nestjs/common';
+import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
 import { ExternalContextCreator } from '@nestjs/core/helpers/external-context-creator';
 import { groupBy } from 'lodash';
 import { AmqpConnection } from './amqp/connection';
 import { AmqpConnectionManager } from './amqp/connectionManager';
-import {
-  RABBIT_ARGS_METADATA,
-  RABBIT_CONFIG_TOKEN,
-  RABBIT_HANDLER,
-} from './rabbitmq.constants';
+import { RABBIT_CONFIG_TOKEN, RABBIT_HANDLER } from './rabbitmq.constants';
 import { RabbitRpcParamsFactory } from './rabbitmq.factory';
 import { RabbitHandlerConfig, RabbitMQConfig } from './rabbitmq.interfaces';
 
@@ -190,7 +187,7 @@ export class RabbitMQModule
               discoveredMethod.parentClass.instance,
               discoveredMethod.handler,
               discoveredMethod.methodName,
-              RABBIT_ARGS_METADATA,
+              ROUTE_ARGS_METADATA,
               this.rpcParamsFactory,
               undefined, // contextId
               undefined, // inquirerId


### PR DESCRIPTION
Fixes https://github.com/golevelup/nestjs/issues/645

nestjs regular `@Param` decorator and such adds the pipes to the metadata (via the reflection methods) using the `'__routeArguments__'` key (https://github.com/nestjs/nest/blob/93b99d09ed84640815fc3aa99196cf94e692bc4d/packages/common/decorators/http/route-params.decorator.ts#L80)

The `DependenciesScanner` of nestjs then loads the `'__routeArguments__'` and injects the pipes in `reflectParamInjectables` (https://github.com/nestjs/nest/blob/master/packages/core/scanner.ts)

golevelup/nestjs however uses the `'RABBIT_ARGS_METADATA'` key for it (https://github.com/golevelup/nestjs/blob/c927cb12f5203fe4739027fc54d78c6ae2629cfb/packages/rabbitmq/src/rabbitmq.decorators.ts), so the scanner will never load and inject them.

I just changed it to `'__routeArguments__'`, and then pipes were correctly created, and their dependencies injected. I don't know enough about the internals to judge if this causes other side-effects. Hopefully tests will catch it all. I wasn't able to run tests locally, so I'm waiting for the ci pipeline to run.