### PR TITLE
fix: use the Logger passed in RabbitMQModule config instead of default

### DIFF
--- a/packages/rabbitmq/src/rabbitmq.module.ts
+++ b/packages/rabbitmq/src/rabbitmq.module.ts
@@ -9,6 +9,8 @@ import {
   Logger,
   OnApplicationBootstrap,
   OnApplicationShutdown,
+  Inject,
+  LoggerService,
 } from '@nestjs/common';
 import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
 import { ExternalContextCreator } from '@nestjs/core/helpers/external-context-creator';
@@ -61,7 +63,7 @@ export class RabbitMQModule
   )
   implements OnApplicationBootstrap, OnApplicationShutdown
 {
-  private readonly logger = new Logger(RabbitMQModule.name);
+  private readonly logger: LoggerService;
 
   private static connectionManager = new AmqpConnectionManager();
   private static bootstrapped = false;
@@ -70,9 +72,11 @@ export class RabbitMQModule
     private readonly discover: DiscoveryService,
     private readonly externalContextCreator: ExternalContextCreator,
     private readonly rpcParamsFactory: RabbitRpcParamsFactory,
-    private readonly connectionManager: AmqpConnectionManager
+    private readonly connectionManager: AmqpConnectionManager,
+    @Inject(RABBIT_CONFIG_TOKEN) config: RabbitMQConfig
   ) {
     super();
+    this.logger = config.logger || new Logger(RabbitMQModule.name);
   }
 
   static async AmqpConnectionFactory(config: RabbitMQConfig) {
@@ -119,7 +123,7 @@ export class RabbitMQModule
   }
 
   async onApplicationShutdown() {
-    this.logger.verbose('Closing AMQP Connections');
+    this.logger.verbose?.('Closing AMQP Connections');
 
     await Promise.all(
       this.connectionManager


### PR DESCRIPTION
Hello, I discovered an issue when passing a custom Logger to the `RabbitMQModule`:

![image](https://github.com/golevelup/nestjs/assets/4543679/ecf9d912-fb44-4bcc-91df-a7481a3ec8cc)


Some logs are made using the logger passed in the config:

![image](https://github.com/golevelup/nestjs/assets/4543679/e349ef13-4960-4b6b-bcfe-144821d877c0)
![image](https://github.com/golevelup/nestjs/assets/4543679/90183240-7150-49ae-9a14-e654c5d8c69c)

But some other logs, like ones written in `onApplicationBootstrap`, don't use the Logger provided in the config but the `logger` property of the `RabbitMQModule` which is not configurable.

![image](https://github.com/golevelup/nestjs/assets/4543679/5ce16819-04f8-4b89-b8e8-dcd8c65b907a)

----

So my fix consists of using the logger from the provided config everywhere in the `RabbitMQModule`.
And now all logs are correct:

![image](https://github.com/golevelup/nestjs/assets/4543679/36bee964-8dbe-46d3-8c06-b8717f889115)



