### PR TITLE
fix issues#667

### DIFF
--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -299,7 +299,7 @@ export class AmqpConnection {
       const { createQueueIfNotExists = true } = configuredQueue;
 
       if (createQueueIfNotExists) {
-        this.setupQueue(configuredQueue, channel);
+        this.setupQueue({...configuredQueue,queue: configuredQueue.name,queueOptions:configuredQueue.options}, channel);
       }
       await channel.assertQueue(configuredQueue.name, configuredQueue.options);
 


### PR DESCRIPTION
Attempt to fix[ issue # 667:](https://github.com/golevelup/nestjs/issues/667)



At present, the queue name attribute corresponds to the queue attribute in Message HandlerOptions, while it corresponds to the name in RabbitMQQueueConfig. There is also an issue of inconsistent queueOptions and options attribute names.

This can cause RabbitMQ to create many anonymous queues (unable to consume and automatically delete) due to no queue in RabbitMQQueueConfig, or channel initialization errors due to different configurations of the same queue at different locations due to the lack of queueOptions.