### PR TITLE
test(rabbitmq): fix createQueueIfNotExists tests not using the createQueueIfNotExists option

### DIFF
--- a/integration/rabbitmq/e2e/configuration.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/configuration.e2e-spec.ts
@@ -170,7 +170,7 @@ describe('Module Configuration', () => {
                 queues: [
                   {
                     name: nonExistingQueue,
-                    createExchangeIfNotExists: false,
+                    createQueueIfNotExists: false,
                   },
                 ],
                 uri,
@@ -201,7 +201,7 @@ describe('Module Configuration', () => {
               queues: [
                 {
                   name: nonExistingQueue,
-                  createExchangeIfNotExists: true,
+                  createQueueIfNotExists: true,
                 },
               ],
               uri,


### PR DESCRIPTION
The createQueueIfNotExists tests were incorrectly using the createExchangeIfNotExists option