### PR TITLE
feat(rabbitmq): add exchange-to-exchange bindings config

### DIFF
--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -90,6 +90,7 @@ const defaultConfig = {
   ),
   defaultSubscribeErrorBehavior: MessageHandlerErrorBehavior.REQUEUE,
   exchanges: [],
+  exchangeBindings: [],
   queues: [],
   defaultRpcTimeout: 10000,
   connectionInitOptions: {
@@ -289,6 +290,17 @@ export class AmqpConnection {
           }
           return channel.checkExchange(x.name);
         })
+      );
+
+      await Promise.all(
+        this.config.exchangeBindings.map((exchangeBinding) =>
+          channel.bindExchange(
+            exchangeBinding.destination,
+            exchangeBinding.source,
+            exchangeBinding.pattern,
+            exchangeBinding.args
+          )
+        )
       );
 
       await this.setupQueuesWithBindings(channel, this.config.queues);

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -23,6 +23,13 @@ export interface RabbitMQQueueConfig {
   bindQueueArguments?: any;
 }
 
+export interface RabbitMQExchangeBindingConfig {
+  destination: string;
+  source: string;
+  pattern: string;
+  args?: any;
+}
+
 export type ConsumeOptions = Options.Consume;
 
 export interface MessageOptions {
@@ -107,6 +114,7 @@ export interface RabbitMQConfig {
    */
   prefetchCount?: number;
   exchanges?: RabbitMQExchangeConfig[];
+  exchangeBindings?: RabbitMQExchangeBindingConfig[];
   queues?: RabbitMQQueueConfig[];
   defaultRpcTimeout?: number;
   defaultExchangeType?: string;


### PR DESCRIPTION
This adds an option to specify exchange bindings in the module config

fix #625