### PR TITLE
fix(ts-vitest): fixed ESM build for ts-vitest

### DIFF
--- a/packages/testing/ts-vitest/src/index.ts
+++ b/packages/testing/ts-vitest/src/index.ts
@@ -1,1 +1,1 @@
-export * from './mocks';
+export * from './mocks.js';

--- a/packages/testing/ts-vitest/tsconfig.json
+++ b/packages/testing/ts-vitest/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
   },
   "include": [
     "./src"


### PR DESCRIPTION
ts-vitest is meant to be imported by vitest as such it needs to be a proper ESM module. The package.json already defined it as "type": "module", but the typescript build was still generating a CommonJS build. This fix updates the typescript configuration to output an ESM module.

re #613