### PR TITLE
feat(amqp/connection.ts): add publishOptions to RequestOptions; use them in AmqpConnection.request

### DIFF
--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -404,6 +404,7 @@ export class AmqpConnection {
       requestOptions.routingKey,
       payload,
       {
+        ...requestOptions.publishOptions,
         replyTo: DIRECT_REPLY_QUEUE,
         correlationId,
         headers: requestOptions.headers,

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -45,6 +45,10 @@ export interface RequestOptions {
   payload?: any;
   headers?: any;
   expiration?: string | number;
+  publishOptions?: Omit<
+    Options.Publish,
+    'replyTo' | 'correlationId' | 'headers' | 'expiration'
+  >;
 }
 
 export interface QueueOptions {


### PR DESCRIPTION
Added a new property named "publishOptions" to the RequestOptions interface so that the additional
options available in the amqplib's Options.Publish interface can be provided when making rpc
requests. Added said usage of the new property to the AmqpConnection.request method's call to
this.publish.

re #719