### PR TITLE
fix(ts-jest): update cache when setting mock property

### DIFF
--- a/packages/testing/ts-jest/src/mocks.spec.ts
+++ b/packages/testing/ts-jest/src/mocks.spec.ts
@@ -88,6 +88,16 @@ describe('Mocks', () => {
       expect(mock.func).toHaveBeenCalledWith(42, '42');
     });
 
+    it('should allow mocked properties to be reassigned', () => {
+      const mock = createMock<TestInterface>();
+
+      mock.someNum = 42;
+      expect(mock.someNum).toBe(42);
+
+      mock.someNum = 43;
+      expect(mock.someNum).toBe(43);
+    });
+
     it('should match mocked instances', () => {
       const mock = createMock<TestInterface>();
       const mockedInstance = createMock<TestClass>({ someProperty: 42 });

--- a/packages/testing/ts-jest/src/mocks.ts
+++ b/packages/testing/ts-jest/src/mocks.ts
@@ -133,6 +133,11 @@ export const createMock = <T extends object>(
       cache.set(prop, mockedProp);
       return mockedProp;
     },
+    set: (obj, prop, newValue) => {
+      cache.set(prop, newValue);
+
+      return Reflect.set(obj, prop, newValue);
+    },
   });
 
   return proxy as DeepMocked<T>;


### PR DESCRIPTION
When assigning a new value to a mock property, add it also to the cache map. The mock will be able to correctly retrieve the updated value afterward.

fixes #578