### PR TITLE
fix(ts-jest): toString doesnt work on nested properties of a mock

### DIFF
--- a/packages/testing/ts-jest/src/mocks.spec.ts
+++ b/packages/testing/ts-jest/src/mocks.spec.ts
@@ -204,6 +204,12 @@ describe('Mocks', () => {
       expect(third.getClient).toBeDefined();
     });
 
+    it('toString should work', () => {
+      const mock = createMock<any>();
+      expect(mock.toString()).toEqual('[object Object]');
+      expect(mock.nested.toString()).toEqual('function () { [native code] }');
+    });
+
     it('should allow for mock implementation on automocked properties', () => {
       const executionContextMock = createMock<ExecutionContext>();
       const httpArgsHost = createMock<HttpArgumentsHost>({

--- a/packages/testing/ts-jest/src/mocks.ts
+++ b/packages/testing/ts-jest/src/mocks.ts
@@ -77,7 +77,7 @@ const createRecursiveMockProxy = (name: string) => {
       const mockedProp =
         prop in obj
           ? typeof checkProp === 'function'
-            ? jest.fn()
+            ? jest.fn(checkProp)
             : checkProp
           : propName === 'then'
           ? undefined


### PR DESCRIPTION
fix: #762