### PR TITLE
feat(stripe): support * wildcard handler

### DIFF
--- a/packages/stripe/src/stripe.module.ts
+++ b/packages/stripe/src/stripe.module.ts
@@ -148,7 +148,7 @@ export class StripeModule
 
     const handleWebhook = async (webhookEvent: { type: string }) => {
       const { type } = webhookEvent;
-      const handlers = webhookHandlers.filter((x) => x.key === type);
+      const handlers = webhookHandlers.filter((x) => x.key === type || x.key === '*');
 
       if (handlers.length) {
         if (


### PR DESCRIPTION
Noticed while setting up the project the `Stripe.Event` type support a wildcard '*' event type, but that event never seemed to fire. 

Added the wildcard to all event filters to make sure it's fired for any event type. 