### PR TITLE
fix(ts-jest): asymmetricMatch should be undefined for nested mocks

### DIFF
--- a/packages/testing/ts-jest/src/mocks.spec.ts
+++ b/packages/testing/ts-jest/src/mocks.spec.ts
@@ -210,6 +210,12 @@ describe('Mocks', () => {
       expect(mock.nested.toString()).toEqual('function () { [native code] }');
     });
 
+    it('asymmetricMatch should not be set', () => {
+      const mock = createMock<any>();
+      expect(mock.asymmetricMatch).toBeUndefined();
+      expect(mock.nested.asymmetricMatch).toBeUndefined();
+    });
+
     it('nested properties mocks should be able to set properties and override cache', () => {
       const mock = createMock<any>();
       const autoMockedFn = mock.nested.f;

--- a/packages/testing/ts-jest/src/mocks.ts
+++ b/packages/testing/ts-jest/src/mocks.ts
@@ -46,10 +46,6 @@ const jestFnProps = new Set([
   'calls',
 ]);
 
-export type MockOptions = {
-  name?: string;
-};
-
 const createProxy: {
   <T extends object>(name: string, base: T): T;
   <T extends Mock<any, any> = Mock<any, any>>(name: string): T;
@@ -116,6 +112,10 @@ const createProxy: {
     };
   }
   return new Proxy(base || (jest.fn() as T), handler);
+};
+
+export type MockOptions = {
+  name?: string;
 };
 
 export const createMock = <T extends object>(


### PR DESCRIPTION
… mocks as well
fix: #767 

I took the liberty to refactor the code so we can have proper code reuse and similar behavior between the main mock and its nested auto mocks. This kind of difference between the types of mocks was already fixed in #763 and now here, so it seems like a good idea :-)