### PR TITLE
feat(rabbitmq): adds a message batching mechanism for RabbitMQ handlers

### DIFF
--- a/integration/rabbitmq/e2e/subscribe.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/subscribe.e2e-spec.ts
@@ -401,6 +401,8 @@ describe('Rabbit Subscribe', () => {
       }
     };
 
+    const paddedBatchTimeout = BATCH_TIMEOUT + 10;
+
     it('should return a full message batch immediately', async () => {
       const testMessages = await publishMessages(
         BATCH_SIZE,
@@ -415,7 +417,7 @@ describe('Rabbit Subscribe', () => {
     it('should return a partial message batch after timeout', async () => {
       const testMessages = await publishMessages(1, exchange, batchRoutingKey);
 
-      await setTimeout(BATCH_TIMEOUT);
+      await setTimeout(paddedBatchTimeout);
       expect(batchHandler).toHaveBeenCalledTimes(1);
       expect(batchHandler).toHaveBeenCalledWith(testMessages);
     });
@@ -443,7 +445,7 @@ describe('Rabbit Subscribe', () => {
         );
       }
 
-      await setTimeout(BATCH_TIMEOUT);
+      await setTimeout(paddedBatchTimeout);
       expect(batchHandler).toHaveBeenCalledTimes(3);
       expect(batchHandler).toHaveBeenLastCalledWith(testMessageBatches[2]);
     });
@@ -477,7 +479,7 @@ describe('Rabbit Subscribe', () => {
         batchErrorRoutingKey,
       );
 
-      await setTimeout(BATCH_TIMEOUT);
+      await setTimeout(paddedBatchTimeout);
       expect(batchErrorHandler).toHaveBeenCalledTimes(1);
       expect(parseMessages(batchErrorHandler.mock.calls[0][1])).toEqual(
         testMessages,
@@ -512,7 +514,7 @@ describe('Rabbit Subscribe', () => {
         );
       }
 
-      await setTimeout(BATCH_TIMEOUT);
+      await setTimeout(paddedBatchTimeout);
       expect(batchErrorHandler).toHaveBeenCalledTimes(3);
       expect(parseMessages(batchErrorHandler.mock.calls[2][1])).toEqual(
         testMessageBatches[2],
@@ -523,27 +525,27 @@ describe('Rabbit Subscribe', () => {
       await publishMessages(BATCH_SIZE, exchange, batchRoutingKey);
       expect(batchHandler).toHaveBeenCalledTimes(1);
 
-      await setTimeout(BATCH_TIMEOUT);
+      await setTimeout(paddedBatchTimeout);
       expect(batchHandler).toHaveBeenCalledTimes(1);
     });
 
     it('should not return a partial batch before batch timeout', async () => {
       await publishMessages(1, exchange, batchRoutingKey);
 
-      await setTimeout(BATCH_TIMEOUT * 0.9);
+      await setTimeout(paddedBatchTimeout * 0.9);
       expect(batchHandler).toHaveBeenCalledTimes(0);
 
-      await setTimeout(BATCH_TIMEOUT * 0.2);
+      await setTimeout(paddedBatchTimeout * 0.2);
       expect(batchHandler).toHaveBeenCalledTimes(1);
     });
 
     it('should not return another partial batch after first batch timeout', async () => {
       await publishMessages(1, exchange, batchRoutingKey);
 
-      await setTimeout(BATCH_TIMEOUT);
+      await setTimeout(paddedBatchTimeout);
       expect(batchHandler).toHaveBeenCalledTimes(1);
 
-      await setTimeout(BATCH_TIMEOUT);
+      await setTimeout(paddedBatchTimeout);
       expect(batchHandler).toHaveBeenCalledTimes(1);
     });
 
@@ -557,7 +559,7 @@ describe('Rabbit Subscribe', () => {
       await setTimeout(1);
       expect(batchErrorHandler).toHaveBeenCalledTimes(1);
 
-      await setTimeout(BATCH_TIMEOUT);
+      await setTimeout(paddedBatchTimeout);
       expect(batchErrorHandler).toHaveBeenCalledTimes(1);
     });
 
@@ -567,10 +569,10 @@ describe('Rabbit Subscribe', () => {
 
       await publishMessages(1, exchange, batchErrorRoutingKey);
 
-      await setTimeout(BATCH_TIMEOUT * 0.9);
+      await setTimeout(paddedBatchTimeout * 0.9);
       expect(batchErrorHandler).toHaveBeenCalledTimes(0);
 
-      await setTimeout(BATCH_TIMEOUT * 0.2);
+      await setTimeout(paddedBatchTimeout * 0.2);
       expect(batchErrorHandler).toHaveBeenCalledTimes(1);
     });
 
@@ -580,10 +582,10 @@ describe('Rabbit Subscribe', () => {
 
       await publishMessages(1, exchange, batchErrorRoutingKey);
 
-      await setTimeout(BATCH_TIMEOUT);
+      await setTimeout(paddedBatchTimeout);
       expect(batchErrorHandler).toHaveBeenCalledTimes(1);
 
-      await setTimeout(BATCH_TIMEOUT);
+      await setTimeout(paddedBatchTimeout);
       expect(batchErrorHandler).toHaveBeenCalledTimes(1);
     });
   });

--- a/integration/rabbitmq/e2e/subscribe.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/subscribe.e2e-spec.ts
@@ -191,7 +191,7 @@ describe('Rabbit Subscribe', () => {
     process.env.NODE_ENV === 'ci' ? process.env.RABBITMQ_HOST : 'localhost';
   const rabbitPort =
     process.env.NODE_ENV === 'ci' ? process.env.RABBITMQ_PORT : '5672';
-  const uri = `amqp://rabbitmq:rabbitmq@${rabbitHost}:${rabbitPort}`;
+  const uri = `amqp://guest:guest@${rabbitHost}:${rabbitPort}`;
 
   beforeAll(async () => {
     const moduleFixture = await Test.createTestingModule({
@@ -378,10 +378,15 @@ describe('Rabbit Subscribe', () => {
   });
 
   describe('Message Batching', () => {
-    const publishMessages = async (size: number, ex: string, rk: string) => {
+    const publishMessages = async (
+      size: number,
+      ex: string,
+      rk: string,
+      prefix = '',
+    ) => {
       const messages: string[] = [];
       for (let i = 0; i < size; i++) {
-        const testMessage = `testMessage${i}`;
+        const testMessage = `${prefix}testMessage${i}`;
         await amqpConnection.publish(ex, rk, testMessage);
         messages.push(testMessage);
       }
@@ -420,9 +425,14 @@ describe('Rabbit Subscribe', () => {
     it('should return multiple batches of differing sizes', async () => {
       const testMessageBatches: string[][] = [];
 
-      for (const size of [BATCH_SIZE, BATCH_SIZE, 1]) {
+      for (const [index, size] of [BATCH_SIZE, BATCH_SIZE, 1].entries()) {
         testMessageBatches.push(
-          await publishMessages(size, exchange, batchRoutingKey),
+          await publishMessages(
+            size,
+            exchange,
+            batchRoutingKey,
+            `batch${index}-`,
+          ),
         );
       }
 
@@ -482,9 +492,14 @@ describe('Rabbit Subscribe', () => {
 
       const testMessageBatches: string[][] = [];
 
-      for (const size of [BATCH_SIZE, BATCH_SIZE, 1]) {
+      for (const [index, size] of [BATCH_SIZE, BATCH_SIZE, 1].entries()) {
         testMessageBatches.push(
-          await publishMessages(size, exchange, batchErrorRoutingKey),
+          await publishMessages(
+            size,
+            exchange,
+            batchErrorRoutingKey,
+            `batch${index}-`,
+          ),
         );
       }
 

--- a/integration/rabbitmq/e2e/subscribe.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/subscribe.e2e-spec.ts
@@ -191,7 +191,7 @@ describe('Rabbit Subscribe', () => {
     process.env.NODE_ENV === 'ci' ? process.env.RABBITMQ_HOST : 'localhost';
   const rabbitPort =
     process.env.NODE_ENV === 'ci' ? process.env.RABBITMQ_PORT : '5672';
-  const uri = `amqp://guest:guest@${rabbitHost}:${rabbitPort}`;
+  const uri = `amqp://rabbitmq:rabbitmq@${rabbitHost}:${rabbitPort}`;
 
   beforeAll(async () => {
     const moduleFixture = await Test.createTestingModule({

--- a/packages/rabbitmq/README.md
+++ b/packages/rabbitmq/README.md
@@ -435,6 +435,39 @@ export class MessagingService {
 }
 ```
 
+### Consumer-side Message Batching
+
+Messages can be presented as a batch to the handler. This works by accumulating messages on the consumer-side until either a batch size limit is reached or the batch timer expires. After handling, all messages in the batch will be acked (or nacked) automatically.
+
+This behaviour is configured in the `batchOptions` property:
+
+```typescript
+import { RabbitSubscribe } from '@golevelup/nestjs-rabbitmq';
+
+const batchErrorHandler = (channel, messages, error) => {
+  console.log(`Received message batch of length: ${messages.length}`);
+};
+
+@Injectable()
+export class MessagingService {
+  @RabbitSubscribe({
+    exchange: 'exchange1',
+    routingKey: 'batch-route',
+    queue: 'batch-queue',
+    batchOptions: {
+      size: 10,
+      timeout: 200,
+      errorHandler: batchErrorHandler,
+    },
+  })
+  public async batchHandler(messages) {
+    console.log(`Received message batch of length: ${messages.length}`);
+  }
+}
+```
+
+An error handler may be provided here if your error handling logic needs to be aware of the batch, otherwise it will fall back to either the top-level `errorHandler` or the default error handling behaviour.
+
 ## Sending Messages
 
 ### Inject the AmqpConnection

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -1016,7 +1016,11 @@ export class AmqpConnection {
         consumer.channel
       );
     } else {
-      throw new Error('Unable to resume consumer, unexpected consumer type.');
+      throw new Error(
+        `Unable to resume consumer tag ${consumerTag}, unexpected consumer type ${
+          (consumer as any).type
+        }.`
+      );
     }
     // A new consumerTag was created, remove old
     this.unregisterConsumerForQueue(consumerTag);

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -572,7 +572,7 @@ export class AmqpConnection {
     let batchSize = msgOptions.batchOptions?.size;
     let batchTimeout = msgOptions.batchOptions?.timeout;
 
-    if (!batchSize || batchSize < 1) {
+    if (!batchSize || batchSize < 2) {
       batchSize = 10;
     }
 

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -687,18 +687,9 @@ export class AmqpConnection {
     handler: RpcSubscriberHandler<T, U>,
     rpcOptions: MessageHandlerOptions
   ): Promise<SubscriptionResult> {
-    return new Promise((res) => {
-      this.selectManagedChannel(rpcOptions?.queueOptions?.channel).addSetup(
-        async (channel) => {
-          const consumerTag = await this.setupRpcChannel<T, U>(
-            handler,
-            rpcOptions,
-            channel
-          );
-          res({ consumerTag });
-        }
-      );
-    });
+    return this.setupChannel(rpcOptions, (channel) =>
+      this.setupRpcChannel<T, U>(handler, rpcOptions, channel)
+    );
   }
 
   public async setupRpcChannel<T, U>(

--- a/packages/rabbitmq/src/amqp/errorBehaviors.ts
+++ b/packages/rabbitmq/src/amqp/errorBehaviors.ts
@@ -1,6 +1,8 @@
 import { Channel, ConsumeMessage } from 'amqplib';
 import { QueueOptions } from '../rabbitmq.interfaces';
 
+export const PRECONDITION_FAILED_CODE = 406;
+
 export enum MessageHandlerErrorBehavior {
   ACK = 'ACK',
   NACK = 'NACK',
@@ -97,7 +99,7 @@ export const forceDeleteAssertQueueErrorHandler: AssertQueueErrorHandler =
     queueOptions: QueueOptions | undefined,
     error: any
   ) => {
-    if (error.code == 406) {
+    if (error.code == PRECONDITION_FAILED_CODE) {
       //406 == preconditions failed
       await channel.deleteQueue(queueName);
       const { queue } = await channel.assertQueue(queueName, queueOptions);

--- a/packages/rabbitmq/src/amqp/errorBehaviors.ts
+++ b/packages/rabbitmq/src/amqp/errorBehaviors.ts
@@ -100,7 +100,6 @@ export const forceDeleteAssertQueueErrorHandler: AssertQueueErrorHandler =
     error: any
   ) => {
     if (error.code == PRECONDITION_FAILED_CODE) {
-      //406 == preconditions failed
       await channel.deleteQueue(queueName);
       const { queue } = await channel.assertQueue(queueName, queueOptions);
       return queue;

--- a/packages/rabbitmq/src/amqp/errorBehaviors.ts
+++ b/packages/rabbitmq/src/amqp/errorBehaviors.ts
@@ -7,31 +7,52 @@ export enum MessageHandlerErrorBehavior {
   REQUEUE = 'REQUEUE',
 }
 
-export type MessageErrorHandler = (
+type BaseMessageErrorHandler<T extends ConsumeMessage | ConsumeMessage[]> = (
   channel: Channel,
-  msg: ConsumeMessage,
+  msg: T,
   error: any
 ) => Promise<void> | void;
 
+export type MessageErrorHandler = BaseMessageErrorHandler<ConsumeMessage>;
+
+export type BatchMessageErrorHandler = BaseMessageErrorHandler<
+  ConsumeMessage[]
+>;
+
+export type LegacyMessageErrorHandler = BaseMessageErrorHandler<
+  ConsumeMessage | ConsumeMessage[]
+>;
 /**
  * An error handler that will ack the message which caused an error during processing
  */
-export const ackErrorHandler: MessageErrorHandler = (channel, msg) => {
-  channel.ack(msg);
+export const ackErrorHandler: LegacyMessageErrorHandler = (channel, msg) => {
+  for (const m of Array.isArray(msg) ? msg : [msg]) {
+    channel.ack(m);
+  }
 };
 
 /**
  * An error handler that will nack and requeue a message which created an error during processing
  */
-export const requeueErrorHandler: MessageErrorHandler = (channel, msg) => {
-  channel.nack(msg, false, true);
+export const requeueErrorHandler: LegacyMessageErrorHandler = (
+  channel,
+  msg
+) => {
+  for (const m of Array.isArray(msg) ? msg : [msg]) {
+    channel.nack(m, false, true);
+  }
 };
 
 /**
  * An error handler that will nack a message which created an error during processing
  */
-export const defaultNackErrorHandler: MessageErrorHandler = (channel, msg) => {
-  channel.nack(msg, false, false);
+export const defaultNackErrorHandler: LegacyMessageErrorHandler = (
+  channel,
+  msg
+) => {
+  for (const m of Array.isArray(msg) ? msg : [msg]) {
+    channel.nack(m, false, false);
+  }
 };
 
 export const getHandlerForLegacyBehavior = (
@@ -69,17 +90,18 @@ export const defaultAssertQueueErrorHandler: AssertQueueErrorHandler = (
 /**
  * Tries to delete the queue and to redeclare it with the provided options
  */
-export const forceDeleteAssertQueueErrorHandler: AssertQueueErrorHandler = async (
-  channel: Channel,
-  queueName: string,
-  queueOptions: QueueOptions | undefined,
-  error: any
-) => {
-  if (error.code == 406) {
-    //406 == preconditions failed
-    await channel.deleteQueue(queueName);
-    const { queue } = await channel.assertQueue(queueName, queueOptions);
-    return queue;
-  }
-  throw error;
-};
+export const forceDeleteAssertQueueErrorHandler: AssertQueueErrorHandler =
+  async (
+    channel: Channel,
+    queueName: string,
+    queueOptions: QueueOptions | undefined,
+    error: any
+  ) => {
+    if (error.code == 406) {
+      //406 == preconditions failed
+      await channel.deleteQueue(queueName);
+      const { queue } = await channel.assertQueue(queueName, queueOptions);
+      return queue;
+    }
+    throw error;
+  };

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -207,11 +207,15 @@ interface BatchOptions {
    * The number of messages to accumulate before calling the message handler.
    *
    * This should be smaller than the channel prefetch.
+   *
+   * Defaults to 10 if provided value is less than 1.
    */
   size: number;
 
   /**
    * The time to wait, in milliseconds, for additional messages before returning a partial batch.
+   *
+   * Defaults to 200 if not provided or provided value is less than 1.
    */
   timeout?: number;
 

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -116,6 +116,11 @@ export interface MessageHandlerOptions {
    * If set, will override the module's default deserializer.
    */
   deserializer?: MessageDeserializer;
+
+  /**
+   * Enables consumer-side batching.
+   */
+  batchOptions?: BatchOptions;
 }
 
 export interface ConnectionInitOptions {
@@ -194,4 +199,18 @@ export interface RabbitMQChannelConfig {
    * If no channel has been marked as default, new channel will be created.
    */
   default?: boolean;
+}
+
+interface BatchOptions {
+  /**
+   * The number of messages to accumulate before calling the message handler.
+   *
+   * This should be smaller than the channel prefetch.
+   */
+  size: number;
+
+  /**
+   * The time to wait, in milliseconds, for additional messages before returning a partial batch.
+   */
+  timeout?: number;
 }

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -4,6 +4,7 @@ import { ConsumeMessage, Options } from 'amqplib';
 import {
   AssertQueueErrorHandler,
   MessageErrorHandler,
+  BatchMessageErrorHandler,
   MessageHandlerErrorBehavior,
 } from './amqp/errorBehaviors';
 
@@ -213,4 +214,9 @@ interface BatchOptions {
    * The time to wait, in milliseconds, for additional messages before returning a partial batch.
    */
   timeout?: number;
+
+  /**
+   * A function that will be called if an error is thrown during processing of an incoming message
+   */
+  errorHandler?: BatchMessageErrorHandler;
 }

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -209,6 +209,8 @@ interface BatchOptions {
    * This should be smaller than the channel prefetch.
    *
    * Defaults to 10 if provided value is less than 2.
+   *
+   * @default 10
    */
   size: number;
 
@@ -216,6 +218,8 @@ interface BatchOptions {
    * The time to wait, in milliseconds, for additional messages before returning a partial batch.
    *
    * Defaults to 200 if not provided or provided value is less than 1.
+   *
+   * @default 200
    */
   timeout?: number;
 

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -208,7 +208,7 @@ interface BatchOptions {
    *
    * This should be smaller than the channel prefetch.
    *
-   * Defaults to 10 if provided value is less than 1.
+   * Defaults to 10 if provided value is less than 2.
    */
   size: number;
 

--- a/packages/rabbitmq/src/rabbitmq.module.ts
+++ b/packages/rabbitmq/src/rabbitmq.module.ts
@@ -169,14 +169,34 @@ export class RabbitMQModule
 
     this.logger.log(handlerDisplayName);
 
-    return config.type === 'rpc'
-      ? connection.createRpc(handler, config)
-      : connection.createSubscriber(
+    switch (config.type) {
+      case 'rpc':
+        return connection.createRpc(handler, config);
+
+      case 'subscribe':
+        if (config.batchOptions) {
+          return connection.createBatchSubscriber(
+            handler,
+            config,
+            discoveredMethod.methodName,
+            config?.queueOptions?.consumerOptions
+          );
+        }
+
+        return connection.createSubscriber(
           handler,
           config,
           discoveredMethod.methodName,
           config?.queueOptions?.consumerOptions
         );
+
+      default:
+        throw new Error(
+          `Unable to set up handler ${handlerDisplayName}. Unexpected handler type ${
+            (config as any).type
+          }.`
+        );
+    }
   }
 
   // eslint-disable-next-line sonarjs/cognitive-complexity

--- a/packages/rabbitmq/src/rabbitmq.module.ts
+++ b/packages/rabbitmq/src/rabbitmq.module.ts
@@ -178,7 +178,6 @@ export class RabbitMQModule
           return connection.createBatchSubscriber(
             handler,
             config,
-            discoveredMethod.methodName,
             config?.queueOptions?.consumerOptions
           );
         }

--- a/packages/rabbitmq/src/rabbitmq.module.ts
+++ b/packages/rabbitmq/src/rabbitmq.module.ts
@@ -192,9 +192,7 @@ export class RabbitMQModule
 
       default:
         throw new Error(
-          `Unable to set up handler ${handlerDisplayName}. Unexpected handler type ${
-            (config as any).type
-          }.`
+          `Unable to set up handler ${handlerDisplayName}. Unexpected handler type ${config.type}.`
         );
     }
   }

--- a/packages/testing/ts-jest/src/mocks.ts
+++ b/packages/testing/ts-jest/src/mocks.ts
@@ -49,6 +49,7 @@ const jestFnProps = new Set([
 const createProxy: {
   <T extends object>(name: string, base: T): T;
   <T extends Mock<any, any> = Mock<any, any>>(name: string): T;
+  // eslint-disable-next-line sonarjs/cognitive-complexity
 } = <T extends object | Mock<any, any>>(name: string, base?: T): T => {
   const cache = new Map<string | number | symbol, any>();
   const handler: ProxyHandler<T> = {


### PR DESCRIPTION
### Message Batching

This implements consumer-side batching (like [Spring](https://docs.spring.io/spring-cloud-stream/reference/rabbit/rabbit_overview/receiving-batch.html#consumer-side-batching)). It works by accumulating messages until either it hits the batch size limit or the batch timer expires at which time the handler will be presented with the messages as a single array which gets acked or nacked together. A batch error handler may be provided for users that require their error handling logic to be aware of the failed batch as a whole.

This is implemented as a new optional message handler options property `batchOptions` which contains:
- `size` representing the maximum batch length before returning the batch
- `timeout` representing the maximum length of time allowed between messages before returning a batch and
- `errorHandler` a custom error handling implementation that receives message batches

At a high-level the batching mechanism works as follows:
1. Initial message is received:
a. Batch timer is started with message handling logic as the callback
b. Store above callback in a separate variable `inflightBatchHandler`
2. Subsequent message is received, check if the batch size has been reached:
a. If it has, clear the batch timer and immediately call `inflightBatchHandler` with the batch
b. Otherwise, refresh the batch timer
3. No message received for batch timeout duration and timer has not been cleared:
a. `inflightBatchHandler` is called by the timer with a partial batch
