### PR TITLE
feat: remove publish generic

### DIFF
--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -624,10 +624,10 @@ export class AmqpConnection {
     return consumerTag;
   }
 
-  public publish<T = any>(
+  public publish(
     exchange: string,
     routingKey: string,
-    message: T,
+    message: any,
     options?: Options.Publish
   ): Promise<boolean> {
     let buffer: Buffer;


### PR DESCRIPTION
The current definition does not bring any value as the generic type T is not used anywhere in the code, but it takes over any attempt to manually override the type of `AmpqConnection` with an ambient definition such as:

```ts
type Events = {
    'event1': { foo: string }
    'event2': { bar: number }
}

declare module '@golevelup/nestjs-rabbitmq' {
    interface AmqpConnection {
        publish<T extends keyof Events>(
            exchange: 'my-exchange',
            routingKey: T,
            message: Events[T],
            opts: Options.Publish
        ): Promise<boolean>
    }
}
```

demo of the type issue here: https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBDAnmApnA3nA8mGwIB2AznAL5wBmUEIcA5AIYgCOYANsAEZ0BQoksDHACCLMAGFCBFAGM8hMpWq06AAQDmENigBuKNgFcwAemlEYAKyIBaKA06dgMFrx5JUcAKJ6CMEgF4MHjgQ+l0UXwBGOgAuIQoICDjzKGACdTJg0Lpw3wAmWKFOBig4ggMQThQoTNIeHgATWTYStBAIBoNteg0tcMMTM0sbOwcnFyDQuDSYaooGGTRRVkkCaTl8Akmp0LADTg4iAAsAHgAVOBQAD1mCBpIAaxRECAovHz8APgAKLJ2d64yI4MdIoOJ0ECIayA4GgugAGj+-1C1AMeHSAGlnnEzojkTsQCgiEQGOowe8In4ANpnAC6ePxoQguCIcRw8mIADoAAr7Q5HJFTACUcW5ymARBQJ04iW0IM+SLqdR4MkI5jgqrWcEC0gA7iIxKt1hzvpgDKlwXQyEL6sZjAgjhLpiRUFAQE5Zg04FUZAwDJLpvB5mw2CQZhAHWhIur+NpCb4GBy4LrHUC4AwQxBdSRCcTSWgYBGqnALoEQYgVVJOXsDhKjt8IVCYSCyQiwh9ovD6AQIDBrAkINYUml1HQbTw7dM3i8DAgoIh02iIKrwNoOV2nMnoA8SOooChE3ADL5gGw54gRwgI2T4EQDOoyeZNiRXpG4LmSWSEMgUBP7YeYEdHMaEpLtALQABJAARTw4CaGRgCaEgqhgXUUAiClfCIGlaTgb48juOCUAoNInE2IV00I8s8OjeAmhIggyMICiQQaP8NRBHt4DAagdEQtA-ULawV3YFAkyINJFkDDU1X4qASEAgCjjQAivXo0ikydLj30TIEUC9Tg0UjdjaLw8sKKdCAHk5Ss1mrPk6wbSFoSuIEWxQNscg7NtMAHOJImtIA

Therefore, i would like to remove it.