### PR TITLE
fix(rmq): allow pattern to contain empty strings for exact/literal matching 

### DIFF
--- a/packages/rabbitmq/src/amqp/utils.ts
+++ b/packages/rabbitmq/src/amqp/utils.ts
@@ -2,12 +2,16 @@ export function matchesRoutingKey(
   routingKey: string,
   pattern: string[] | string | undefined
 ): boolean {
-  if (!pattern) return false;
+  // An empty string is a valid pattern therefore
+  // we should only exclude null values and empty array
+  if (pattern === undefined || (Array.isArray(pattern) && pattern.length === 0))
+    return false;
+
   const patterns = Array.isArray(pattern) ? pattern : [pattern];
-  for (const pattern of patterns) {
-    if (routingKey === pattern) return true;
+  for (const p of patterns) {
+    if (routingKey === p) return true;
     const splitKey = routingKey.split('.');
-    const splitPattern = pattern.split('.');
+    const splitPattern = p.split('.');
     let starFailed = false;
     for (let i = 0; i < splitPattern.length; i++) {
       if (splitPattern[i] === '#') return true;

--- a/packages/rabbitmq/src/tests/rabbitmq.utils.spec.ts
+++ b/packages/rabbitmq/src/tests/rabbitmq.utils.spec.ts
@@ -41,7 +41,7 @@ describe(matchesRoutingKey.name, () => {
       ['event.#', 'user.#'],
       true,
     ],
-    ['should return true with pattern as an empty string', '', '', false], //both are equal (empty strings) which is valid for an exact match
+    ['should return true with pattern as an empty string', '', '', true], //both are equal (empty strings) which is valid for an exact match
     [
       'should return false when routing key does not match any pattern in the array',
       'user.updated',

--- a/packages/rabbitmq/src/tests/rabbitmq.utils.spec.ts
+++ b/packages/rabbitmq/src/tests/rabbitmq.utils.spec.ts
@@ -1,57 +1,61 @@
 import { matchesRoutingKey } from '../amqp/utils';
 
-describe('matchesRoutingKey', () => {
+describe(matchesRoutingKey.name, () => {
   const userCreated = 'user.created';
-  it('should return true when routing key matches star pattern', () => {
-    const routingKey = 'user.created.new';
-    const pattern = 'user.*.new';
-    const result = matchesRoutingKey(routingKey, pattern);
-    expect(result).toBe(true);
-  });
-  it('should return true when routing key matches hash pattern', () => {
-    const routingKey = 'user.updated.new';
-    const pattern = 'user.#';
-    const result = matchesRoutingKey(routingKey, pattern);
-    expect(result).toBe(true);
-  });
-  it('should return false when routing key does not match pattern', () => {
-    const routingKey = 'user.updated';
-    const pattern = userCreated;
-    const result = matchesRoutingKey(routingKey, pattern);
-    expect(result).toBe(false);
-  });
 
-  it('should return true when routing key matches any star pattern in the array', () => {
-    const routingKey = userCreated;
-    const pattern = ['event.*', 'user.*'];
+  it.each([
+    // [description, routingKey, pattern, expectedResult]
+    [
+      'should return true when routing key matches star pattern',
+      'user.created.new',
+      'user.*.new',
+      true,
+    ],
+    [
+      'should return true when routing key matches hash pattern',
+      'user.updated.new',
+      'user.#',
+      true,
+    ],
+    [
+      'should return false when routing key does not match pattern',
+      'user.updated',
+      userCreated,
+      false,
+    ],
+    [
+      'should return true when routing key matches any star pattern in the array',
+      userCreated,
+      ['event.*', 'user.*'],
+      true,
+    ],
+    [
+      'should return true when routing key matches precise pattern in the array with wildcards',
+      userCreated,
+      ['user.*.new', userCreated, 'event.#'],
+      true,
+    ],
+    [
+      'should return true when routing key matches any hash pattern in the array',
+      'user.created.new',
+      ['event.#', 'user.#'],
+      true,
+    ],
+    ['should return true with pattern as an empty string', '', '', false], //both are equal (empty strings) which is valid for an exact match
+    [
+      'should return false when routing key does not match any pattern in the array',
+      'user.updated',
+      [userCreated, 'event.created'],
+      false,
+    ],
+    [
+      'should return false when pattern is undefined',
+      userCreated,
+      undefined,
+      false,
+    ],
+  ])('%s', (_, routingKey, pattern, expectedResult) => {
     const result = matchesRoutingKey(routingKey, pattern);
-    expect(result).toBe(true);
-  });
-
-  it('should return true when routing key matches precise pattern in the array with wildcards', () => {
-    const routingKey = userCreated;
-    const pattern = ['user.*.new', userCreated, 'event.#'];
-    const result = matchesRoutingKey(routingKey, pattern);
-    expect(result).toBe(true);
-  });
-
-  it('should return true when routing key matches any hash pattern in the array', () => {
-    const routingKey = 'user.created.new';
-    const pattern = ['event.#', 'user.#'];
-    const result = matchesRoutingKey(routingKey, pattern);
-    expect(result).toBe(true);
-  });
-  it('should return false when routing key does not match any pattern in the array', () => {
-    const routingKey = 'user.updated';
-    const pattern = [userCreated, 'event.created'];
-    const result = matchesRoutingKey(routingKey, pattern);
-    expect(result).toBe(false);
-  });
-
-  it('should return false when pattern is undefined', () => {
-    const routingKey = userCreated;
-    const pattern = undefined;
-    const result = matchesRoutingKey(routingKey, pattern);
-    expect(result).toBe(false);
+    expect(result).toBe(expectedResult);
   });
 });


### PR DESCRIPTION
### Improvements
- Developers can specifically empty routing keys and patterns for exact/literal matching.

### Context
Recently a user has reported that empty strings were not being accepted but are a valid value for rmq. There's more context over this issue #786 
