### PR TITLE
feat(stripe): upgrade to v16 

### DIFF
--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -41,10 +41,10 @@
     "@golevelup/nestjs-modules": "^0.7.1"
   },
   "devDependencies": {
-    "stripe": "^14.19.0"
+    "stripe": "^16.12.0"
   },
   "peerDependencies": {
-    "stripe": "^14.19.0"
+    "stripe": "^16.12.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/packages/stripe/src/stripe.module.ts
+++ b/packages/stripe/src/stripe.module.ts
@@ -48,7 +48,7 @@ export class StripeModule
           useFactory: ({
             apiKey,
             typescript = true,
-            apiVersion = '2023-10-16',
+            apiVersion = '2024-06-20',
             webhookConfig,
             ...options
           }: StripeModuleConfig): Stripe => {
@@ -148,7 +148,9 @@ export class StripeModule
 
     const handleWebhook = async (webhookEvent: { type: string }) => {
       const { type } = webhookEvent;
-      const handlers = webhookHandlers.filter((x) => x.key === type || x.key === '*');
+      const handlers = webhookHandlers.filter(
+        (x) => x.key === type || x.key === '*'
+      );
 
       if (handlers.length) {
         if (

--- a/packages/stripe/src/stripe.webhook.controller.ts
+++ b/packages/stripe/src/stripe.webhook.controller.ts
@@ -10,7 +10,7 @@ export class StripeWebhookController {
 
   constructor(
     @InjectStripeModuleConfig()
-    private readonly config: StripeModuleConfig,
+    config: StripeModuleConfig,
     private readonly stripePayloadService: StripePayloadService,
     private readonly stripeWebhookService: StripeWebhookService
   ) {

--- a/packages/stripe/src/stripe.webhook.service.ts
+++ b/packages/stripe/src/stripe.webhook.service.ts
@@ -5,7 +5,7 @@ import { STRIPE_WEBHOOK_SERVICE } from './stripe.constants';
 @SetMetadata(STRIPE_WEBHOOK_SERVICE, true)
 export class StripeWebhookService {
   public handleWebhook(evt: any): any {
-    // The implementation for this method is overriden by the containing module
+    // The implementation for this method is overridden by the containing module
     console.log(evt);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10338,10 +10338,10 @@ strip-literal@^2.0.0:
   dependencies:
     js-tokens "^8.0.2"
 
-stripe@^14.19.0:
-  version "14.19.0"
-  resolved "https://registry.yarnpkg.com/stripe/-/stripe-14.19.0.tgz#d254024620a61029fbf50667205f720844645d78"
-  integrity sha512-Je2USTpUib3hApIgoHXViLoYkDLp+AXdUJvJ6aMQ/AcvZK1PcC7N8nTceh+0gpdotX8izlWN4QyVdMcptubHBQ==
+stripe@^16.12.0:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/stripe/-/stripe-16.12.0.tgz#75e3d8f0f35bea14885cb3605a41d6afc182aa66"
+  integrity sha512-H7eFVLDxeTNNSn4JTRfL2//LzCbDrMSZ+2q1c7CanVWgK2qIW5TwS+0V7N9KcKZZNpYh/uCqK0PyZh/2UsaAtQ==
   dependencies:
     "@types/node" ">=8.1.0"
     qs "^6.11.0"


### PR DESCRIPTION
### Improvements
- Developers can leverage the latest stripe version `v16`

Closes #746 

### Breaking changes
For any breaking change related to Stripe please refer to https://docs.stripe.com/upgrades.
Golevelup module does not change internally as it seems to be working just fine (tested locally and in CI w/tests)