### PR TITLE
chore(ci): drop nodejs 18 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  LATEST_NODE_VERSION: 18
+  LATEST_NODE_VERSION: 20
 
 jobs:
   ci:
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [18, 20, 22]
+        node: [20, 22]
       fail-fast: false
 
     services:


### PR DESCRIPTION
Nodejs LTS is now set to `v20.x.x` 