### PR TITLE
feat: upgrade stripe to `v17` 

### DIFF
--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -41,10 +41,10 @@
     "@golevelup/nestjs-modules": "^0.7.1"
   },
   "devDependencies": {
-    "stripe": "^16.12.0"
+    "stripe": "^17.1.0"
   },
   "peerDependencies": {
-    "stripe": "^16.12.0"
+    "stripe": "^17.1.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/packages/stripe/src/stripe.module.ts
+++ b/packages/stripe/src/stripe.module.ts
@@ -3,7 +3,7 @@ import { createConfigurableDynamicRootModule } from '@golevelup/nestjs-modules';
 import { Logger, Module, OnModuleInit } from '@nestjs/common';
 import { PATH_METADATA } from '@nestjs/common/constants';
 import { ExternalContextCreator } from '@nestjs/core/helpers/external-context-creator';
-import { flatten, groupBy } from 'lodash';
+import { flatten, groupBy, omit } from 'lodash';
 import Stripe from 'stripe';
 import {
   STRIPE_CLIENT_TOKEN,
@@ -54,7 +54,7 @@ export class StripeModule
             return new Stripe(apiKey, {
               typescript,
               apiVersion,
-              ...options,
+              ...omit(options, ['webhookConfig']),
             });
           },
           inject: [STRIPE_MODULE_CONFIG_TOKEN],

--- a/packages/stripe/src/stripe.module.ts
+++ b/packages/stripe/src/stripe.module.ts
@@ -48,7 +48,7 @@ export class StripeModule
           useFactory: ({
             apiKey,
             typescript = true,
-            apiVersion = '2024-06-20',
+            apiVersion = '2024-09-30.acacia',
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             webhookConfig,
             ...options

--- a/packages/stripe/src/stripe.module.ts
+++ b/packages/stripe/src/stripe.module.ts
@@ -49,8 +49,6 @@ export class StripeModule
             apiKey,
             typescript = true,
             apiVersion = '2024-09-30.acacia',
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            webhookConfig,
             ...options
           }: StripeModuleConfig): Stripe => {
             return new Stripe(apiKey, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,8 +309,8 @@ importers:
         version: 0.7.1(@nestjs/common@10.4.4(reflect-metadata@0.2.2)(rxjs@7.8.1))(rxjs@7.8.1)
     devDependencies:
       stripe:
-        specifier: ^16.12.0
-        version: 16.12.0
+        specifier: ^17.1.0
+        version: 17.1.0
 
   packages/testing/ts-jest:
     devDependencies:
@@ -4673,8 +4673,8 @@ packages:
   strip-literal@2.1.0:
     resolution: {integrity: sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==}
 
-  stripe@16.12.0:
-    resolution: {integrity: sha512-H7eFVLDxeTNNSn4JTRfL2//LzCbDrMSZ+2q1c7CanVWgK2qIW5TwS+0V7N9KcKZZNpYh/uCqK0PyZh/2UsaAtQ==}
+  stripe@17.1.0:
+    resolution: {integrity: sha512-sNRsJx7LPP2Gg6cBJoHJqhr+UoBVZZRes2BDqbrg+1FDBxJc4Yn+LkrpJ/VnL3XQ3+6I5GrOUnSSFfE/joDFjw==}
     engines: {node: '>=12.*'}
 
   strong-log-transformer@2.1.0:
@@ -10497,7 +10497,7 @@ snapshots:
       js-tokens: 9.0.0
     optional: true
 
-  stripe@16.12.0:
+  stripe@17.1.0:
     dependencies:
       '@types/node': 20.16.10
       qs: 6.13.0


### PR DESCRIPTION
## Changes
- Stripe is upgraded to `v17` 

### Breaking changes
If you're using our module please make sure you read the breaking changes introduced with `v17` 

https://docs.stripe.com/upgrades#2024-09-30.acacia
https://github.com/stripe/stripe-node/releases