### PR TITLE
feat(ts-jest): add a test file showcasing regression in 0.5.1

### DIFF
--- a/packages/testing/ts-jest/src/temp.spec.ts
+++ b/packages/testing/ts-jest/src/temp.spec.ts
@@ -1,0 +1,24 @@
+import { createMock } from './mocks';
+
+interface TestInterface {
+  func: () => Promise<Counter>;
+}
+
+type Counter = {
+  count: number;
+};
+
+describe('regression', () => {
+  it('showcases the regression', async () => {
+    expect.hasAssertions();
+    const testmock = createMock<TestInterface>();
+
+    const c = await testmock.func();
+    try {
+      c.count < 0;
+    } catch (e) {
+      if (e instanceof Error)
+        expect(e.message).toBe('Cannot convert object to primitive value');
+    }
+  });
+});


### PR DESCRIPTION
This tests passes on 0.5.1, but fails on 0.5.0

This branch is only meant to showcase the change of behaviour introduced in a patch version of the `@golevelup/ts-jest` library.