### PR TITLE
fix(ts-jest): ensures auto mocked properties can be casted to primitive types

### DIFF
--- a/packages/testing/ts-jest/src/mocks.spec.ts
+++ b/packages/testing/ts-jest/src/mocks.spec.ts
@@ -9,6 +9,7 @@ interface TestInterface {
   optional: string | undefined;
   func: (num: number, str: string) => boolean;
   func2: (entity: TestClass) => void;
+  func3: () => Promise<{ prop: number }>;
 }
 
 class TestClass {
@@ -224,6 +225,25 @@ describe('Mocks', () => {
       const mock = createMock<any>();
       expect(mock.toString()).toEqual('[object Object]');
       expect(mock.nested.toString()).toEqual('function () { [native code] }');
+    });
+    it('nested properties can be implictly casted to string', () => {
+      const mock = createMock<{ nested: any }>();
+
+      const testFnNumber = () => mock.nested > 0;
+      const testFnString = () => `${mock.nested}`;
+
+      expect(testFnNumber).not.toThrowError();
+      expect(testFnString).not.toThrowError();
+    });
+    it('mocked functions returned values can be implictly casted to string', async () => {
+      const mock = createMock<TestInterface>();
+      const result = await mock.func3();
+
+      const testFnNumber = () => result.prop > 0;
+      const testFnString = () => `${result.prop}`;
+
+      expect(testFnNumber).not.toThrowError();
+      expect(testFnString).not.toThrowError();
     });
 
     it('asymmetricMatch should not be set', () => {

--- a/packages/testing/ts-jest/src/mocks.ts
+++ b/packages/testing/ts-jest/src/mocks.ts
@@ -85,6 +85,19 @@ const createProxy: {
         mockedProp = createProxy(`${name}.${propName}`);
       }
 
+      // Add Symbol.toPrimitive to preserve implicit conversion to primitive types
+      if (typeof mockedProp === 'object' || typeof mockedProp === 'function') {
+        mockedProp[Symbol.toPrimitive] = (hint) => {
+          if (hint === 'string') {
+            return 'mocked';
+          }
+          if (hint === 'number') {
+            return 0;
+          }
+          throw new TypeError();
+        };
+      }
+
       cache.set(prop, mockedProp);
       return mockedProp;
     },


### PR DESCRIPTION
Addresses a unintended behaviour change introduced in version 0.5.1

fix #843