### PR TITLE
new AmqpConnection() should NOT cause an error

### DIFF
--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -147,7 +147,7 @@ export class AmqpConnection {
     this.config = {
       deserializer: (message) => JSON.parse(message.toString()),
       serializer: (value) => Buffer.from(JSON.stringify(value)),
-      logger: config.logger || new Logger(AmqpConnection.name),
+      logger: config?.logger || new Logger(AmqpConnection.name),
       ...defaultConfig,
       ...config,
     };

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -147,7 +147,7 @@ export class AmqpConnection {
     this.config = {
       deserializer: (message) => JSON.parse(message.toString()),
       serializer: (value) => Buffer.from(JSON.stringify(value)),
-      logger: config.logger ?? new Logger(AmqpConnection.name),
+      logger: config?.logger || new Logger(AmqpConnection.name),
       ...defaultConfig,
       ...config,
     };

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -147,7 +147,7 @@ export class AmqpConnection {
     this.config = {
       deserializer: (message) => JSON.parse(message.toString()),
       serializer: (value) => Buffer.from(JSON.stringify(value)),
-      logger: config?.logger || new Logger(AmqpConnection.name),
+      logger: config.logger ?? new Logger(AmqpConnection.name),
       ...defaultConfig,
       ...config,
     };


### PR DESCRIPTION
When `new AmqpConnection()` with no arguments, it should NOT error but it does