### PR TITLE
fix(ts-jest): ts-jest: toPrimitive should not be set on proxies, but …

### DIFF
--- a/packages/testing/ts-jest/src/mocks.spec.ts
+++ b/packages/testing/ts-jest/src/mocks.spec.ts
@@ -226,6 +226,15 @@ describe('Mocks', () => {
       expect(mock.toString()).toEqual('[object Object]');
       expect(mock.nested.toString()).toEqual('function () { [native code] }');
     });
+
+    it('mock should equal its partial', () => {
+      const mock = createMock<any>();
+      expect({ mock }).toEqual({ mock: {} });
+      const partialMock = createMock<any>({ foo: { bar: 1 } });
+      expect({ partialMock }).toEqual({ partialMock: { foo: { bar: 1 } } });
+      expect({ foo: partialMock.foo }).toEqual({ foo: { bar: 1 } });
+    });
+
     it('nested properties can be implictly casted to string', () => {
       const mock = createMock<{ nested: any }>();
 
@@ -377,7 +386,7 @@ describe('Mocks', () => {
 
       mockedProvider = module.get<DeepMocked<ExecutionContext>>(diToken);
       dependentProvider = module.get<{ dependent: () => string }>(
-        dependentToken
+        dependentToken,
       );
     });
 
@@ -389,7 +398,7 @@ describe('Mocks', () => {
       mockedProvider.switchToHttp.mockReturnValueOnce(
         createMock<HttpArgumentsHost>({
           getRequest: () => request,
-        })
+        }),
       );
 
       const mockResult = mockedProvider.switchToHttp().getRequest();

--- a/packages/testing/ts-jest/src/mocks.spec.ts
+++ b/packages/testing/ts-jest/src/mocks.spec.ts
@@ -233,24 +233,25 @@ describe('Mocks', () => {
       expect({ foo: mock.foo }).toEqual({ foo: { bar: 1 } });
     });
 
-    it('nested properties can be implictly casted to string', () => {
+    it('nested properties can not be implictly casted to string/number', () => {
       const mock = createMock<{ nested: any }>();
 
       const testFnNumber = () => mock.nested > 0;
       const testFnString = () => `${mock.nested}`;
 
-      expect(testFnNumber).not.toThrowError();
-      expect(testFnString).not.toThrowError();
+      expect(testFnNumber).toThrowError();
+      expect(testFnString).toThrowError();
     });
-    it('mocked functions returned values can be implictly casted to string', async () => {
+
+    it('mocked functions returned values can not be implictly casted to string/number', async () => {
       const mock = createMock<TestInterface>();
       const result = await mock.func3();
 
       const testFnNumber = () => result.prop > 0;
       const testFnString = () => `${result.prop}`;
 
-      expect(testFnNumber).not.toThrowError();
-      expect(testFnString).not.toThrowError();
+      expect(testFnNumber).toThrowError();
+      expect(testFnString).toThrowError();
     });
 
     it('asymmetricMatch should not be set', () => {

--- a/packages/testing/ts-jest/src/mocks.spec.ts
+++ b/packages/testing/ts-jest/src/mocks.spec.ts
@@ -227,12 +227,10 @@ describe('Mocks', () => {
       expect(mock.nested.toString()).toEqual('function () { [native code] }');
     });
 
-    it('mock should equal its partial', () => {
-      const mock = createMock<any>();
-      expect({ mock }).toEqual({ mock: {} });
-      const partialMock = createMock<any>({ foo: { bar: 1 } });
-      expect({ partialMock }).toEqual({ partialMock: { foo: { bar: 1 } } });
-      expect({ foo: partialMock.foo }).toEqual({ foo: { bar: 1 } });
+    it('nested properties should equal its partial', () => {
+      const mock = createMock<any>({ foo: { bar: 1 } });
+      expect({ mock }).toEqual({ mock: { foo: { bar: 1 } } });
+      expect({ foo: mock.foo }).toEqual({ foo: { bar: 1 } });
     });
 
     it('nested properties can be implictly casted to string', () => {

--- a/packages/testing/ts-jest/src/mocks.ts
+++ b/packages/testing/ts-jest/src/mocks.ts
@@ -46,16 +46,6 @@ const jestFnProps = new Set([
   'calls',
 ]);
 
-const toPrimitive = (hint: 'string' | 'number' | 'default') => {
-  if (hint === 'string') {
-    return 'mocked';
-  }
-  if (hint === 'number') {
-    return 0;
-  }
-  throw new TypeError();
-};
-
 const createProxy: {
   <T extends object>(name: string, base: T): T;
   <T extends Mock<any, any> = Mock<any, any>>(name: string): T;
@@ -76,10 +66,6 @@ const createProxy: {
 
       if (!base && jestFnProps.has(propName)) {
         return Reflect.get(obj, prop, receiver);
-      }
-
-      if (!(prop in obj) && prop == Symbol.toPrimitive) {
-        return toPrimitive;
       }
 
       if (cache.has(prop)) {

--- a/packages/testing/ts-jest/src/mocks.ts
+++ b/packages/testing/ts-jest/src/mocks.ts
@@ -46,7 +46,7 @@ const jestFnProps = new Set([
   'calls',
 ]);
 
-const toPrimitive = (hint) => {
+const toPrimitive = (hint: string) => {
   if (hint === 'string') {
     return 'mocked';
   }

--- a/packages/testing/ts-jest/src/mocks.ts
+++ b/packages/testing/ts-jest/src/mocks.ts
@@ -46,7 +46,7 @@ const jestFnProps = new Set([
   'calls',
 ]);
 
-const toPrimitive = (hint: string) => {
+const toPrimitive = (hint: 'string' | 'number' | 'default') => {
   if (hint === 'string') {
     return 'mocked';
   }


### PR DESCRIPTION
…mocked when needed

regression introduced in #850
@JonasFaure you can't just add properties to the mocks as it interferes with libraries that makes comparison, like jest-when

