### PR TITLE
fix(rabbitmq): allow more valid `vhost` names in `assertRabbitMqUri`

### DIFF
--- a/packages/rabbitmq/src/amqp/utils.ts
+++ b/packages/rabbitmq/src/amqp/utils.ts
@@ -29,7 +29,7 @@ export function matchesRoutingKey(
 }
 
 const rabbitMQRegex =
-  /^amqps?:\/\/(([^:]+):([^@]+)@)?([^:/]+)(:[0-9]+)?(\/[^\/]*)?$/;
+  /^amqps?:\/\/(([^:]+):([^@]+)@)?([^:/]+)(:[0-9]+)?(\/.*)?$/;
 
 /**
  * Validates a rabbitmq uri

--- a/packages/rabbitmq/src/tests/rabbitmq.utils.spec.ts
+++ b/packages/rabbitmq/src/tests/rabbitmq.utils.spec.ts
@@ -72,6 +72,8 @@ describe(matchesRoutingKey.name, () => {
           'amqps://rabbitmq:rabbitmq@localhost:2345',
           'amqp://rabbitmq:rabbitmq@localhost:3456/',
           'amqps://rabbitmq:rabbitmq@localhost:4567/',
+          'amqps://rabbitmq:rabbitmq@localhost:4567/vhost',
+          'amqps://rabbitmq:rabbitmq@localhost:4567/v/h(o&s*t_',
         ]),
       ).not.toThrowError();
     });


### PR DESCRIPTION
fix(packages/rabbitmq/src/amqp/utils.ts): allow more valid `vhost` names in `assertRabbitMqUri`

fix #880