### PR TITLE
feat: graphql-request module use nestjs `ConfigurableModuleClass` 

### DIFF
--- a/packages/graphql-request/package.json
+++ b/packages/graphql-request/package.json
@@ -38,9 +38,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@golevelup/nestjs-common": "workspace:^",
-    "@golevelup/nestjs-discovery": "workspace:^",
-    "@golevelup/nestjs-modules": "workspace:^",
     "graphql": "^16.10.0",
     "graphql-request": "^6.1.0"
   },

--- a/packages/graphql-request/src/graphql-request-module-definition.ts
+++ b/packages/graphql-request/src/graphql-request-module-definition.ts
@@ -1,0 +1,11 @@
+import { ConfigurableModuleBuilder } from '@nestjs/common';
+import { GraphQLRequestModuleConfig } from './graphql-request-types';
+
+export const {
+  ConfigurableModuleClass,
+  MODULE_OPTIONS_TOKEN,
+  OPTIONS_TYPE,
+  ASYNC_OPTIONS_TYPE,
+} = new ConfigurableModuleBuilder<GraphQLRequestModuleConfig>()
+  .setClassMethodName('forRoot')
+  .build();

--- a/packages/graphql-request/src/graphql-request-module-definition.ts
+++ b/packages/graphql-request/src/graphql-request-module-definition.ts
@@ -1,11 +1,7 @@
 import { ConfigurableModuleBuilder } from '@nestjs/common';
 import { GraphQLRequestModuleConfig } from './graphql-request-types';
 
-export const {
-  ConfigurableModuleClass,
-  MODULE_OPTIONS_TOKEN,
-  OPTIONS_TYPE,
-  ASYNC_OPTIONS_TYPE,
-} = new ConfigurableModuleBuilder<GraphQLRequestModuleConfig>()
-  .setClassMethodName('forRoot')
-  .build();
+export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN } =
+  new ConfigurableModuleBuilder<GraphQLRequestModuleConfig>()
+    .setClassMethodName('forRoot')
+    .build();

--- a/packages/graphql-request/src/graphql-request-types.ts
+++ b/packages/graphql-request/src/graphql-request-types.ts
@@ -1,0 +1,10 @@
+import { GraphQLClient } from 'graphql-request';
+
+type GraphQLClientConstructorParams = ConstructorParameters<
+  typeof GraphQLClient
+>;
+
+export interface GraphQLRequestModuleConfig {
+  endpoint: GraphQLClientConstructorParams[0];
+  options?: GraphQLClientConstructorParams[1];
+}

--- a/packages/graphql-request/src/graphql-request.decorators.ts
+++ b/packages/graphql-request/src/graphql-request.decorators.ts
@@ -1,4 +1,4 @@
-import { makeInjectableDecorator } from '@golevelup/nestjs-common';
+import { Inject } from '@nestjs/common';
 import {
   GraphQLClientConfigInject,
   GraphQLClientInject,
@@ -7,11 +7,9 @@ import {
 /**
  * Injects the GraphQL client configuration from this module into a service/controller
  */
-export const InjectGraphQLConfig = makeInjectableDecorator(
-  GraphQLClientConfigInject
-);
+export const InjectGraphQLConfig = () => Inject(GraphQLClientConfigInject);
 
 /**
  * Injects the GraphQL client provided by this module into a service/controller
  */
-export const InjectGraphQLClient = makeInjectableDecorator(GraphQLClientInject);
+export const InjectGraphQLClient = () => Inject(GraphQLClientInject);

--- a/packages/graphql-request/src/graphql-request.module.ts
+++ b/packages/graphql-request/src/graphql-request.module.ts
@@ -1,33 +1,21 @@
-import { createConfigurableDynamicRootModule } from '@golevelup/nestjs-modules';
 import { Module } from '@nestjs/common';
 import { GraphQLClient } from 'graphql-request';
 import {
-  GraphQLClientConfigInject,
-  GraphQLClientInject,
-} from './graphql-request.constants';
+  ConfigurableModuleClass,
+  MODULE_OPTIONS_TOKEN,
+} from './graphql-request-module-definition';
+import { GraphQLRequestModuleConfig } from './graphql-request-types';
+import { GraphQLClientInject } from './graphql-request.constants';
 
-type GraphQLClientConstructorParams = ConstructorParameters<
-  typeof GraphQLClient
->;
-
-export interface GraphQLRequestModuleConfig {
-  endpoint: GraphQLClientConstructorParams[0];
-  options?: GraphQLClientConstructorParams[1];
-}
-
-@Module({})
-export class GraphQLRequestModule extends createConfigurableDynamicRootModule<
-  GraphQLRequestModule,
-  GraphQLRequestModuleConfig
->(GraphQLClientConfigInject, {
+@Module({
   providers: [
     {
       provide: GraphQLClientInject,
+      inject: [MODULE_OPTIONS_TOKEN],
       useFactory: ({ endpoint, options }: GraphQLRequestModuleConfig) => {
         return new GraphQLClient(endpoint, options);
       },
-      inject: [GraphQLClientConfigInject],
     },
   ],
-  exports: [GraphQLClientInject],
-}) {}
+})
+export class GraphQLRequestModule extends ConfigurableModuleClass {}

--- a/packages/graphql-request/src/index.ts
+++ b/packages/graphql-request/src/index.ts
@@ -1,3 +1,4 @@
 export * from './graphql-request.constants';
 export * from './graphql-request.decorators';
 export * from './graphql-request.module';
+export * from './graphql-request-types';

--- a/packages/graphql-request/src/test/graphql-request.module.spec.ts
+++ b/packages/graphql-request/src/test/graphql-request.module.spec.ts
@@ -1,29 +1,38 @@
-import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { GraphQLClient } from 'graphql-request';
 import { GraphQLRequestModule } from '../graphql-request.module';
 import { GraphQLClientInject } from './../graphql-request.constants';
 
 describe('GraphQL Request Module', () => {
-  let app: INestApplication;
-  let client: GraphQLClient;
-
-  beforeEach(async () => {
+  it('provides a graphql client', async () => {
     const moduleFixture = await Test.createTestingModule({
       imports: [
-        GraphQLRequestModule.forRoot(GraphQLRequestModule, {
+        GraphQLRequestModule.forRoot({
           endpoint: 'some-graphql-endpoint',
         }),
       ],
     }).compile();
 
-    app = moduleFixture.createNestApplication();
-    await app.init();
+    const app = moduleFixture.createNestApplication();
+    const client = app.get<GraphQLClient>(GraphQLClientInject);
 
-    client = app.get<GraphQLClient>(GraphQLClientInject);
+    expect(client).toBeInstanceOf(GraphQLClient);
   });
 
-  it('provides a graphql client', () => {
+  it('provides a graphql client with async factory', async () => {
+    const moduleFixture = await Test.createTestingModule({
+      imports: [
+        GraphQLRequestModule.forRootAsync({
+          useFactory: () => ({
+            endpoint: 'test',
+          }),
+        }),
+      ],
+    }).compile();
+
+    const app = moduleFixture.createNestApplication();
+    const client = app.get<GraphQLClient>(GraphQLClientInject);
+
     expect(client).toBeInstanceOf(GraphQLClient);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,15 +206,6 @@ importers:
 
   packages/graphql-request:
     dependencies:
-      '@golevelup/nestjs-common':
-        specifier: workspace:^
-        version: link:../common
-      '@golevelup/nestjs-discovery':
-        specifier: workspace:^
-        version: link:../discovery
-      '@golevelup/nestjs-modules':
-        specifier: workspace:^
-        version: link:../modules
       graphql:
         specifier: ^16.10.0
         version: 16.10.0
@@ -2272,8 +2263,8 @@ packages:
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
-  cross-fetch@3.1.8:
-    resolution: {integrity: sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==}
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -7712,7 +7703,7 @@ snapshots:
   create-require@1.1.1:
     optional: true
 
-  cross-fetch@3.1.8(encoding@0.1.13):
+  cross-fetch@3.2.0(encoding@0.1.13):
     dependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
     transitivePeerDependencies:
@@ -8490,7 +8481,7 @@ snapshots:
   graphql-request@6.1.0(encoding@0.1.13)(graphql@16.10.0):
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
-      cross-fetch: 3.1.8(encoding@0.1.13)
+      cross-fetch: 3.2.0(encoding@0.1.13)
       graphql: 16.10.0
     transitivePeerDependencies:
       - encoding


### PR DESCRIPTION
- Refactors `GraphQLRequestModule` to simply leverage Nestjs `ConfigurableModuleClass` making it easier to bootstrap and require less dependencies

This update will introduce breaking changes to existing consumers

### Previous API of initializing `GraphQLRequestModule`
```typescript
 GraphQLRequestModule.forRoot(GraphQLRequestModule, {
          endpoint: 'some-graphql-endpoint',
  })
```
### New API
```typescript
  GraphQLRequestModule.forRoot({
          endpoint: 'some-graphql-endpoint',
   })
```
