### PR TITLE
refactor: rabbitmq module use nestjs `ConfigurableModuleClass` 

### DIFF
--- a/integration/rabbitmq/e2e/cancel-and-resume.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/cancel-and-resume.e2e-spec.ts
@@ -24,7 +24,7 @@ describe('Rabbit Cancel and Resume', () => {
     const moduleFixture = await Test.createTestingModule({
       providers: [],
       imports: [
-        RabbitMQModule.forRoot(RabbitMQModule, {
+        RabbitMQModule.forRoot({
           exchanges: [
             {
               name: exchange,

--- a/integration/rabbitmq/e2e/connection-failover.e2e-spec1.ts
+++ b/integration/rabbitmq/e2e/connection-failover.e2e-spec1.ts
@@ -63,7 +63,7 @@ export class RestController {
 
 @Module({
   imports: [
-    RabbitMQModule.forRoot(RabbitMQModule, {
+    RabbitMQModule.forRoot({
       exchanges: [
         {
           name: exchange,

--- a/integration/rabbitmq/e2e/execution-context.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/execution-context.e2e-spec.ts
@@ -52,7 +52,7 @@ describe('Rabbit Subscribe Without Register Handlers', () => {
     const moduleFixture = await Test.createTestingModule({
       providers: [SubscribeService, TestInterceptor],
       imports: [
-        RabbitMQModule.forRoot(RabbitMQModule, {
+        RabbitMQModule.forRoot({
           exchanges: [
             {
               name: exchange,

--- a/integration/rabbitmq/e2e/graceful-shutdown.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/graceful-shutdown.e2e-spec.ts
@@ -54,7 +54,7 @@ describe('Rabbit Graceful Shutdown', () => {
     const moduleFixture = await Test.createTestingModule({
       providers: [SubscribeService],
       imports: [
-        RabbitMQModule.forRoot(RabbitMQModule, {
+        RabbitMQModule.forRoot({
           uri,
           connectionInitOptions: { wait: true, reject: true, timeout: 3000 },
         }),

--- a/integration/rabbitmq/e2e/multiple-channels.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/multiple-channels.e2e-spec.ts
@@ -150,7 +150,7 @@ describe('Rabbit Multiple Channels', () => {
     const moduleFixture = await Test.createTestingModule({
       providers: [SubscribeToMultipleChannelsService],
       imports: [
-        RabbitMQModule.forRoot(RabbitMQModule, {
+        RabbitMQModule.forRoot({
           exchanges: [
             {
               name: exchange,

--- a/integration/rabbitmq/e2e/nack-and-requeue.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/nack-and-requeue.e2e-spec.ts
@@ -60,7 +60,7 @@ describe('Nack and Requeue', () => {
     const moduleFixture = await Test.createTestingModule({
       providers: [SubscribeService],
       imports: [
-        RabbitMQModule.forRootAsync(RabbitMQModule, {
+        RabbitMQModule.forRootAsync({
           useFactory: () => ({
             exchanges: [
               {

--- a/integration/rabbitmq/e2e/rmq-context.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/rmq-context.e2e-spec.ts
@@ -50,7 +50,7 @@ describe('RMQ Context in Global interceptor', () => {
     const moduleFixture = await Test.createTestingModule({
       providers: [SubscribeService, TestInterceptor],
       imports: [
-        RabbitMQModule.forRoot(RabbitMQModule, {
+        RabbitMQModule.forRoot({
           exchanges: [
             {
               name: exchange,

--- a/integration/rabbitmq/e2e/rpc-no-direct-reply.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/rpc-no-direct-reply.e2e-spec.ts
@@ -39,7 +39,7 @@ describe('Rabbit Direct Reply To', () => {
     const moduleFixture = await Test.createTestingModule({
       providers: [RpcService],
       imports: [
-        RabbitMQModule.forRoot(RabbitMQModule, {
+        RabbitMQModule.forRoot({
           exchanges: [
             {
               name: exchange,

--- a/integration/rabbitmq/e2e/serialization.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/serialization.e2e-spec.ts
@@ -77,7 +77,7 @@ describe('Rabbit Subscribe', () => {
         SubscribeHandlerSerializationService,
       ],
       imports: [
-        RabbitMQModule.forRoot(RabbitMQModule, {
+        RabbitMQModule.forRoot({
           exchanges: [
             {
               name: exchange,

--- a/integration/rabbitmq/e2e/subscribe-no-handlers.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/subscribe-no-handlers.e2e-spec.ts
@@ -38,7 +38,7 @@ describe('Rabbit Subscribe Without Register Handlers', () => {
     const moduleFixture = await Test.createTestingModule({
       providers: [SubscribeService],
       imports: [
-        RabbitMQModule.forRoot(RabbitMQModule, {
+        RabbitMQModule.forRoot({
           exchanges: [
             {
               name: exchange,

--- a/integration/rabbitmq/e2e/subscribe.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/subscribe.e2e-spec.ts
@@ -195,7 +195,7 @@ describe('Rabbit Subscribe', () => {
     const moduleFixture = await Test.createTestingModule({
       providers: [SubscribeService],
       imports: [
-        RabbitMQModule.forRoot(RabbitMQModule, {
+        RabbitMQModule.forRoot({
           exchanges: [
             {
               name: exchange,

--- a/integration/rabbitmq/src/app.module.ts
+++ b/integration/rabbitmq/src/app.module.ts
@@ -13,7 +13,7 @@ const uri = `amqp://rabbitmq:rabbitmq@${rabbitHost}:${rabbitPort}`;
 
 @Module({
   imports: [
-    RabbitMQModule.forRootAsync(RabbitMQModule, {
+    RabbitMQModule.forRootAsync({
       useFactory: () => ({
         exchanges: [
           {

--- a/integration/rabbitmq/src/controller-discovery/controller-discovery.module.ts
+++ b/integration/rabbitmq/src/controller-discovery/controller-discovery.module.ts
@@ -11,7 +11,7 @@ const uri = `amqp://rabbitmq:rabbitmq@${rabbitHost}:${rabbitPort}`;
 
 @Module({
   imports: [
-    RabbitMQModule.forRootAsync(RabbitMQModule, {
+    RabbitMQModule.forRootAsync({
       useFactory: () => ({
         exchanges: [
           {

--- a/integration/rabbitmq/src/named-connection/named-connection.module.ts
+++ b/integration/rabbitmq/src/named-connection/named-connection.module.ts
@@ -11,7 +11,7 @@ const uri = `amqp://rabbitmq:rabbitmq@${rabbitHost}:${rabbitPort}`;
 
 @Module({
   imports: [
-    RabbitMQModule.forRootAsync(RabbitMQModule, {
+    RabbitMQModule.forRootAsync({
       useFactory: () => ({
         name: CONNECTION_NAME,
         exchanges: [

--- a/packages/rabbitmq/README.md
+++ b/packages/rabbitmq/README.md
@@ -71,7 +71,7 @@ import { RabbitMQModule } from '@golevelup/nestjs-rabbitmq';
 
 @Module({
   imports: [
-    RabbitMQModule.forRoot(RabbitMQModule, {
+    RabbitMQModule.forRoot({
       exchanges: [
         {
           name: 'exchange1',
@@ -116,7 +116,7 @@ import { MessagingService } from './messaging/messaging.service';
 
 @Module({
   imports: [
-    RabbitMQModule.forRoot(RabbitMQModule, {
+    RabbitMQModule.forRoot({
       exchanges: [
         {
           name: 'exchange1',
@@ -149,13 +149,16 @@ This library is built using an underlying NestJS concept called `External Contex
 You can identify RabbitMQ contexts by their context type, `'rmq'`:
 
 ```typescript
+import { RABBIT_CONTEXT_TYPE_KEY } from '@golevelup/nestjs-rabbitmq';
 @Injectable()
 class ExampleInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler<any>) {
-    const contextType = context.getType<'http' | 'rmq'>();
+    const contextType = context.getType<
+      'http' | typeof RABBIT_CONTEXT_TYPE_KEY
+    >();
 
     // Do nothing if this is a RabbitMQ event
-    if (contextType === 'rmq') {
+    if (contextType === RABBIT_CONTEXT_TYPE_KEY) {
       return next.handle();
     }
 
@@ -199,7 +202,7 @@ import { MessagingService } from './messaging/messaging.service';
 
 @Module({
   imports: [
-    RabbitMQModule.forRoot(RabbitMQModule, {
+    RabbitMQModule.forRoot({
       exchanges: [
         {
           name: 'exchange1',
@@ -312,12 +315,12 @@ import { ConsumeMessage } from 'amqplib';
 
 @Module({
   imports: [
-    RabbitMQModule.forRoot(RabbitMQModule, {
+    RabbitMQModule.forRoot({
       // ...
       deserializer: (message: Buffer, msg: ConsumeMessage) => {
         const decodedMessage = myCustomDeserializer(
           msg.toString(),
-          msg.properties.headers
+          msg.properties.headers,
         );
         return decodedMessage;
       },
@@ -654,7 +657,7 @@ import { RabbitMQModule } from '@golevelup/nestjs-rabbitmq';
             uri: 'amqp://rabbitmq:rabbitmq@localhost:5672',
             connectionInitOptions: { wait: false },
           }
-        : undefined
+        : undefined,
     ),
   ],
 })

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -34,9 +34,7 @@
     "url": "https://github.com/golevelup/nestjs/issues"
   },
   "dependencies": {
-    "@golevelup/nestjs-common": "workspace:^",
     "@golevelup/nestjs-discovery": "workspace:^",
-    "@golevelup/nestjs-modules": "workspace:^",
     "amqp-connection-manager": "^4.1.14",
     "amqplib": "^0.10.5",
     "lodash": "^4.17.21"
@@ -47,7 +45,7 @@
   "peerDependencies": {
     "@nestjs/common": "^10.x",
     "@nestjs/core": "^10.x",
-    "reflect-metadata": "^0.1.0 || ^0.2.0",
+    "reflect-metadata": "^0.2.2",
     "rxjs": "^7.x"
   },
   "publishConfig": {

--- a/packages/rabbitmq/src/rabbitmq-module-definition.ts
+++ b/packages/rabbitmq/src/rabbitmq-module-definition.ts
@@ -1,0 +1,7 @@
+import { ConfigurableModuleBuilder } from '@nestjs/common';
+import { RabbitMQConfig } from './rabbitmq.interfaces';
+
+export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN } =
+  new ConfigurableModuleBuilder<RabbitMQConfig>()
+    .setClassMethodName('forRoot')
+    .build();

--- a/packages/rabbitmq/src/rabbitmq.constants.ts
+++ b/packages/rabbitmq/src/rabbitmq.constants.ts
@@ -1,5 +1,7 @@
+import { MODULE_OPTIONS_TOKEN } from './rabbitmq-module-definition';
+
 export const RABBIT_HANDLER = Symbol('RABBIT_HANDLER');
-export const RABBIT_CONFIG_TOKEN = Symbol('RABBIT_CONFIG');
+export const RABBIT_CONFIG_TOKEN = MODULE_OPTIONS_TOKEN;
 export const RABBIT_PARAM_TYPE = 3;
 export const RABBIT_HEADER_TYPE = 4;
 export const RABBIT_REQUEST_TYPE = 5;

--- a/packages/rabbitmq/src/rabbitmq.decorators.ts
+++ b/packages/rabbitmq/src/rabbitmq.decorators.ts
@@ -1,4 +1,3 @@
-import { makeInjectableDecorator } from '@golevelup/nestjs-common';
 import 'reflect-metadata';
 import {
   applyDecorators,
@@ -6,6 +5,7 @@ import {
   PipeTransform,
   Type,
   assignMetadata,
+  Inject,
 } from '@nestjs/common';
 import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
 import { isString } from 'lodash';
@@ -36,8 +36,7 @@ export const RabbitSubscribe = makeRabbitDecorator({ type: 'subscribe' });
 
 export const RabbitRPC = makeRabbitDecorator({ type: 'rpc' });
 
-export const InjectRabbitMQConfig =
-  makeInjectableDecorator(RABBIT_CONFIG_TOKEN);
+export const InjectRabbitMQConfig = () => Inject(RABBIT_CONFIG_TOKEN);
 
 export const createPipesRpcParamDecorator =
   (

--- a/packages/rabbitmq/src/tests/rabbitmq-module.spec.ts
+++ b/packages/rabbitmq/src/tests/rabbitmq-module.spec.ts
@@ -1,0 +1,31 @@
+import { Test } from '@nestjs/testing';
+import { AmqpConnectionManager } from '../amqp/connectionManager';
+import { RABBIT_CONFIG_TOKEN } from '../rabbitmq.constants';
+import { RabbitMQConfig } from '../rabbitmq.interfaces';
+import { RabbitMQModule } from '../rabbitmq.module';
+
+const uri = 'amqp://rabbitmq:rabbitmq@test:5555';
+
+describe(RabbitMQModule.name, () => {
+  it('should create the module successfully', async () => {
+    const moduleFixture = await Test.createTestingModule({
+      imports: [
+        RabbitMQModule.forRoot({
+          uri,
+        }),
+      ],
+    })
+      .overrideProvider(AmqpConnectionManager)
+      .useValue(new AmqpConnectionManager())
+      .compile();
+
+    const app = moduleFixture.createNestApplication();
+    const connectionManager = app.get<AmqpConnectionManager>(
+      AmqpConnectionManager,
+    );
+    const config = app.get<RabbitMQConfig>(RABBIT_CONFIG_TOKEN);
+
+    expect(connectionManager).toBeInstanceOf(AmqpConnectionManager);
+    expect(config).toEqual(expect.objectContaining({ uri }));
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,15 +252,9 @@ importers:
 
   packages/rabbitmq:
     dependencies:
-      '@golevelup/nestjs-common':
-        specifier: workspace:^
-        version: link:../common
       '@golevelup/nestjs-discovery':
         specifier: workspace:^
         version: link:../discovery
-      '@golevelup/nestjs-modules':
-        specifier: workspace:^
-        version: link:../modules
       '@nestjs/common':
         specifier: ^10.x
         version: 10.4.4(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -277,7 +271,7 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       reflect-metadata:
-        specifier: ^0.1.0 || ^0.2.0
+        specifier: ^0.2.2
         version: 0.2.2
       rxjs:
         specifier: ^7.x


### PR DESCRIPTION
## Improvements
- RabbitMQ Module utilizes `ConfigurableModuleClass` from Nestjs

## Breaking Changes
- Initializing `RabbitMQModule` no longer requires the module to be provided

### New API
```typescript
RabbitMQModule.forRoot({
  uri: 'amqp://rabbitmq:rabbitmq@localhost:5672',
})
```