### PR TITLE
chore: remove deprecated dependency `@types/mime`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@types/express": "5.0.0",
     "@types/jest": "^27.0.3",
     "@types/lodash": "^4.17.14",
-    "@types/mime": "3.0.4",
     "@types/node": "^22.0.0",
     "@types/supertest": "^6.0.2",
     "@typescript-eslint/eslint-plugin": "^8.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,9 +61,6 @@ importers:
       '@types/lodash':
         specifier: ^4.17.14
         version: 4.17.14
-      '@types/mime':
-        specifier: 3.0.4
-        version: 3.0.4
       '@types/node':
         specifier: ^22.0.0
         version: 22.7.5
@@ -1658,9 +1655,6 @@ packages:
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
-
-  '@types/mime@3.0.4':
-    resolution: {integrity: sha512-iJt33IQnVRkqeqC7PzBHPTC6fDlRNRW8vjrgqtScAhrmMwe8c4Eo7+fUGTa+XdWrpEgpyKWMYmi2dIwMAYRzPw==}
 
   '@types/minimatch@3.0.5':
     resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
@@ -7498,8 +7492,6 @@ snapshots:
   '@types/methods@1.1.4': {}
 
   '@types/mime@1.3.5': {}
-
-  '@types/mime@3.0.4': {}
 
   '@types/minimatch@3.0.5': {}
 


### PR DESCRIPTION
- Removes deprecated dev dependency `@types/mime`