### PR TITLE
feat: support for consumerTag configuration in RabbitMQ

### DIFF
--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -526,7 +526,8 @@ export class AmqpConnection {
         async (channel: ConfirmChannel) => {
           const consumerTag = await setupFunction(
             channel,
-            // msgOptions over global config
+            // Override global configuration by merging the global/default
+            // tag configuration with the parametized msgOption.
             merge(consumerTagConfig, msgOptions),
           );
           res({ consumerTag });

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -470,10 +470,10 @@ export class AmqpConnection {
     originalHandlerName: string,
     consumeOptions?: ConsumeOptions,
   ): Promise<SubscriptionResult> {
-    return this.consumerFactory(msgOptions, (channel, msgOptions) =>
+    return this.consumerFactory(msgOptions, (channel, channelMsgOptions) =>
       this.setupSubscriberChannel<T>(
         handler,
-        msgOptions,
+        channelMsgOptions,
         channel,
         originalHandlerName,
         consumeOptions,
@@ -486,10 +486,10 @@ export class AmqpConnection {
     msgOptions: MessageHandlerOptions,
     consumeOptions?: ConsumeOptions,
   ): Promise<SubscriptionResult> {
-    return this.consumerFactory(msgOptions, (channel, msgOptions) =>
+    return this.consumerFactory(msgOptions, (channel, channelMsgOptions) =>
       this.setupBatchSubscriberChannel<T>(
         handler,
-        msgOptions,
+        channelMsgOptions,
         channel,
         consumeOptions,
       ),
@@ -744,8 +744,8 @@ export class AmqpConnection {
     handler: RpcSubscriberHandler<T, U>,
     rpcOptions: MessageHandlerOptions,
   ): Promise<SubscriptionResult> {
-    return this.consumerFactory(rpcOptions, (channel, rpcOptions) =>
-      this.setupRpcChannel<T, U>(handler, rpcOptions, channel),
+    return this.consumerFactory(rpcOptions, (channel, channelRpcOptions) =>
+      this.setupRpcChannel<T, U>(handler, channelRpcOptions, channel),
     );
   }
 

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -28,7 +28,7 @@ export interface RabbitMQQueueConfig {
    * Consumer tag must be unique to one channel. You shoudld properly manage
    * channels and tags in your local space in order to avoid conflicts.
    *
-   * More info: https://amqp-node.github.io/amqplib/channel_api.html#channel_consume
+   * @see {@link https://amqp-node.github.io/amqplib/channel_api.html#channel_consume|Channel API reference}
    */
   consumerTag?: string | undefined;
 }

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -22,6 +22,7 @@ export interface RabbitMQQueueConfig {
   exchange?: string;
   routingKey?: string | string[];
   bindQueueArguments?: any;
+  consumerTag?: string | undefined;
 }
 
 export interface RabbitMQExchangeBindingConfig {

--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -22,6 +22,14 @@ export interface RabbitMQQueueConfig {
   exchange?: string;
   routingKey?: string | string[];
   bindQueueArguments?: any;
+  /**
+   * This property can be set to define custom consumer name for the queue.
+   *
+   * Consumer tag must be unique to one channel. You shoudld properly manage
+   * channels and tags in your local space in order to avoid conflicts.
+   *
+   * More info: https://amqp-node.github.io/amqplib/channel_api.html#channel_consume
+   */
   consumerTag?: string | undefined;
 }
 

--- a/packages/rabbitmq/src/tests/amqp.connection.spec.ts
+++ b/packages/rabbitmq/src/tests/amqp.connection.spec.ts
@@ -15,10 +15,6 @@ const mockConfig = {
       name: 'queue_1',
       consumerTag: 'consumer_tag_1',
     },
-    {
-      name: 'queue_2',
-      consumerTag: 'consumer_tag_1',
-    },
   ],
 };
 
@@ -88,13 +84,13 @@ describe('AmqpConnection', () => {
     );
   });
 
-  it('should use provided consumer tag', async () => {
+  it('should use locally defined consumer tag', async () => {
     const mockHandler = jest.fn();
     const mockRpcOptions = {
       queue: 'queue_1',
       queueOptions: {
         consumerOptions: {
-          consumerTag: 'local_consumer_tag',
+          consumerTag: 'consumer_tag_local',
         },
       },
     };
@@ -103,7 +99,14 @@ describe('AmqpConnection', () => {
 
     expect(connection.setupRpcChannel).toHaveBeenCalledWith(
       mockHandler,
-      mockRpcOptions,
+      {
+        queue: 'queue_1',
+        queueOptions: {
+          consumerOptions: {
+            consumerTag: 'consumer_tag_local',
+          },
+        },
+      },
       mockChannel,
     );
   });

--- a/packages/rabbitmq/src/tests/amqp.connection.spec.ts
+++ b/packages/rabbitmq/src/tests/amqp.connection.spec.ts
@@ -10,6 +10,16 @@ const mockConfig = {
   password: 'guest',
   vhost: '/',
   uri: 'amqp://guest:guest@localhost:5672/',
+  queues: [
+    {
+      name: 'queue_1',
+      consumerTag: 'consumer_tag_1',
+    },
+    {
+      name: 'queue_2',
+      consumerTag: 'consumer_tag_1',
+    },
+  ],
 };
 
 describe('AmqpConnection', () => {
@@ -41,7 +51,7 @@ describe('AmqpConnection', () => {
       mockHandler,
       mockMsgOptions,
       mockHandlerName,
-      mockConsumeOptions
+      mockConsumeOptions,
     );
 
     expect(result).toEqual({ consumerTag: mockConsumerTag });
@@ -54,5 +64,47 @@ describe('AmqpConnection', () => {
     const result = await connection.createRpc(mockHandler, mockRpcOptions);
 
     expect(result).toEqual({ consumerTag: mockConsumerTag });
+  });
+
+  it('should inherit consumer tag from global config', async () => {
+    const mockHandler = jest.fn();
+    const mockRpcOptions = {
+      queue: 'queue_1',
+    };
+
+    await connection.createRpc(mockHandler, mockRpcOptions);
+
+    expect(connection.setupRpcChannel).toHaveBeenCalledWith(
+      mockHandler,
+      {
+        queue: 'queue_1',
+        queueOptions: {
+          consumerOptions: {
+            consumerTag: 'consumer_tag_1',
+          },
+        },
+      },
+      mockChannel,
+    );
+  });
+
+  it('should use provided consumer tag', async () => {
+    const mockHandler = jest.fn();
+    const mockRpcOptions = {
+      queue: 'queue_1',
+      queueOptions: {
+        consumerOptions: {
+          consumerTag: 'local_consumer_tag',
+        },
+      },
+    };
+
+    await connection.createRpc(mockHandler, mockRpcOptions);
+
+    expect(connection.setupRpcChannel).toHaveBeenCalledWith(
+      mockHandler,
+      mockRpcOptions,
+      mockChannel,
+    );
   });
 });


### PR DESCRIPTION
Related to https://github.com/golevelup/nestjs/issues/904.

Since the consumerTag global settings can be used in several places, I have placed the processing in factory method, and forwarded the updated object from factory method further into the call function.

I found that queue options to which the consumerTag configuration was supposed to be added, extends the internal types of amqplib, so I had to declare the configuration one level higher. The final configuration can be look like this:

```
RabbitMQModule.forRootAsync(RabbitMQModule, {
  useFactory: () => ({
    uri: 'amqp://localhost:5672',
    exchanges: [{ name: 'exchange_name', type: 'topic' }],
    queues: [
      {
        name: 'queue_name',
        consumerTag: 'custom_consumer_tag',
        options: {
          // ... more options here
        },
      },
    ],
  }),
});
```

If local consumerTag settings are passed during consumer initialization, global settings are ignored. Added a couple of tests to check this.