### PR TITLE
fix: support stripe 20

### DIFF
--- a/docs/modules/stripe.md
+++ b/docs/modules/stripe.md
@@ -136,6 +136,14 @@ class PaymentCreatedService {
   handlePaymentIntentCreated(evt: Stripe.PaymentIntentPaymentCreatedEvent) {
     // execute your custom business logic
   }
+
+  @StripeWebhookHandler('v1.billing.meter.no_meter_found')
+  handleBillingMeterNoMeterFound(
+    nft: Stripe.Events.V1BillingMeterNoMeterFoundEventNotification,
+  ) {
+    const event = await nft.fetchEvent();
+    // execute your custom business logic
+  }
 }
 ```
 

--- a/docs/modules/stripe.md
+++ b/docs/modules/stripe.md
@@ -138,7 +138,7 @@ class PaymentCreatedService {
   }
 
   @StripeWebhookHandler('v1.billing.meter.no_meter_found')
-  handleBillingMeterNoMeterFound(
+  async handleBillingMeterNoMeterFound(
     nft: Stripe.Events.V1BillingMeterNoMeterFoundEventNotification,
   ) {
     const event = await nft.fetchEvent();

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -39,10 +39,10 @@
     "@golevelup/nestjs-discovery": "workspace:^"
   },
   "devDependencies": {
-    "stripe": "^18.2.1"
+    "stripe": "^20.0.0"
   },
   "peerDependencies": {
-    "stripe": "^18.2.1"
+    "stripe": "^20.0.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/packages/stripe/src/stripe.decorators.ts
+++ b/packages/stripe/src/stripe.decorators.ts
@@ -19,8 +19,11 @@ export const InjectStripeClient = () => Inject(STRIPE_CLIENT_TOKEN);
 /**
  * Binds the decorated service method as a handler for incoming Stripe Webhook events.
  * Events will be automatically routed here based on their event type property
- * @param config The configuration for this handler
+ *
+ * @param eventType The Stripe event type to bind the handler to (either normal or thin events)
  */
 export const StripeWebhookHandler = (
-  eventType: Stripe.WebhookEndpointCreateParams.EnabledEvent,
+  eventType:
+    | Stripe.WebhookEndpointCreateParams.EnabledEvent
+    | Stripe.V2.Core.Event['type'],
 ) => SetMetadata(STRIPE_WEBHOOK_HANDLER, eventType);

--- a/packages/stripe/src/stripe.module.ts
+++ b/packages/stripe/src/stripe.module.ts
@@ -47,7 +47,7 @@ import { StripeWebhookService } from './stripe.webhook.service';
       useFactory: ({
         apiKey,
         typescript = true,
-        apiVersion = '2025-05-28.basil',
+        apiVersion = '2025-11-17.clover',
         ...options
       }: StripeModuleConfig): Stripe => {
         return new Stripe(apiKey, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,8 +279,8 @@ importers:
         version: link:../discovery
     devDependencies:
       stripe:
-        specifier: ^18.2.1
-        version: 18.2.1(@types/node@22.16.5)
+        specifier: ^20.0.0
+        version: 20.0.0(@types/node@22.16.5)
 
   packages/testing/ts-jest:
     devDependencies:
@@ -5255,11 +5255,11 @@ packages:
   strip-literal@2.1.0:
     resolution: {integrity: sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==}
 
-  stripe@18.2.1:
-    resolution: {integrity: sha512-GwB1B7WSwEBzW4dilgyJruUYhbGMscrwuyHsPUmSRKrGHZ5poSh2oU9XKdii5BFVJzXHn35geRvGJ6R8bYcp8w==}
-    engines: {node: '>=12.*'}
+  stripe@20.0.0:
+    resolution: {integrity: sha512-EaZeWpbJOCcDytdjKSwdrL5BxzbDGNueiCfHjHXlPdBQvLqoxl6AAivC35SPzTmVXJb5duXQlXFGS45H0+e6Gg==}
+    engines: {node: '>=16'}
     peerDependencies:
-      '@types/node': '>=12.x.x'
+      '@types/node': '>=16'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -11797,7 +11797,7 @@ snapshots:
       js-tokens: 9.0.0
     optional: true
 
-  stripe@18.2.1(@types/node@22.16.5):
+  stripe@20.0.0(@types/node@22.16.5):
     dependencies:
       qs: 6.14.0
     optionalDependencies:


### PR DESCRIPTION
This PR updates nestjs-stripe package to support for Stripe's latest v20 release and also adds support for stripe's thin events