### PR TITLE
feat: ts-vitest to latest vitest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "vitepress": "^1.6.3"
   },
   "optionalDependencies": {
-    "@vitest/coverage-v8": "^1.6.1",
-    "vitest": "^1.6.1"
+    "@vitest/coverage-v8": "^4.0.16",
+    "vitest": "^4.0.16"
   },
   "scripts": {
     "commit": "pnpm git-cz",

--- a/packages/testing/ts-vitest/package.json
+++ b/packages/testing/ts-vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@golevelup/ts-vitest",
-  "version": "0.5.2",
+  "version": "1.0.0",
   "description": "Reusable utilities to help level up NestJS Testing",
   "author": "Jesse Carter <jesse.r.carter@gmail.com>",
   "homepage": "https://github.com/golevelup/nestjs#readme",
@@ -8,6 +8,8 @@
   "type": "module",
   "keywords": [
     "NestJS",
+    "vitest",
+    "vite",
     "testing",
     "utilities",
     "levelup"
@@ -35,6 +37,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "6f97aab8ce9d65dc074750a3ee467ec5ff3b9908"
+  }
 }

--- a/packages/testing/ts-vitest/src/index.ts
+++ b/packages/testing/ts-vitest/src/index.ts
@@ -1,2 +1,2 @@
 export { createMock } from './mocks.js';
-export { type DeepMockedType, type PartialMockInput } from './type-helper.js';
+export { type DeepMocked, type PartialFuncReturn } from './type-helper.js';

--- a/packages/testing/ts-vitest/src/index.ts
+++ b/packages/testing/ts-vitest/src/index.ts
@@ -1,1 +1,2 @@
-export * from './mocks.js';
+export { createMock } from './mocks.js';
+export { type DeepMockedType, type PartialMockInput } from './type-helper.js';

--- a/packages/testing/ts-vitest/src/mocks.spec.ts
+++ b/packages/testing/ts-vitest/src/mocks.spec.ts
@@ -1,8 +1,9 @@
 import { ExecutionContext } from '@nestjs/common';
-import { HttpArgumentsHost } from '@nestjs/common/interfaces';
 import { Test, TestingModule } from '@nestjs/testing';
-import { createMock, DeepMocked } from './mocks';
 import { describe, it, beforeEach, expect } from 'vitest';
+import { createMock } from './mocks.js';
+import { DeepPartial } from './type-helper.js';
+import { HttpArgumentsHost } from '@nestjs/common/interfaces/index.js';
 
 interface TestInterface {
   someNum: number;
@@ -254,7 +255,7 @@ describe('Mocks', () => {
 
   describe('Nest DI', () => {
     let module: TestingModule;
-    let mockedProvider: DeepMocked<ExecutionContext>;
+    let mockedProvider = createMock<ExecutionContext>();
     let dependentProvider: { dependent: () => string };
     const diToken = Symbol('diToken');
     const dependentToken = Symbol('dependentToken');
@@ -271,16 +272,16 @@ describe('Mocks', () => {
           {
             inject: [diToken],
             provide: dependentToken,
-            useFactory: (dep: DeepMocked<ExecutionContext>) => ({
+            useFactory: (dep: DeepPartial<ExecutionContext>) => ({
               dependent: dep.getType,
             }),
           },
         ],
       }).compile();
 
-      mockedProvider = module.get<DeepMocked<ExecutionContext>>(diToken);
+      mockedProvider = module.get(diToken);
       dependentProvider = module.get<{ dependent: () => string }>(
-        dependentToken
+        dependentToken,
       );
     });
 
@@ -292,7 +293,7 @@ describe('Mocks', () => {
       mockedProvider.switchToHttp.mockReturnValueOnce(
         createMock<HttpArgumentsHost>({
           getRequest: () => request,
-        })
+        }),
       );
 
       const mockResult = mockedProvider.switchToHttp().getRequest();

--- a/packages/testing/ts-vitest/src/mocks.ts
+++ b/packages/testing/ts-vitest/src/mocks.ts
@@ -1,105 +1,198 @@
-import { ArgumentsType, MockInstance, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import { vi } from 'vitest';
+import { DeepMockedType, PartialMockInput } from './type-helper.js';
 
-type DeepPartial<T> = {
-  [P in keyof T]?: T[P] extends Array<infer U>
-    ? Array<DeepPartial<U>>
-    : T[P] extends ReadonlyArray<infer U>
-      ? ReadonlyArray<DeepPartial<U>>
-      : unknown extends T[P]
-        ? T[P]
-        : DeepPartial<T[P]>;
-};
+/**
+ * Set of property names that are part of Vitest's Mock function API. These keys are handled directly by the underlying vi.fn() mock instance and should not be intercepted by our proxy. This ensures that all Vitest mock methods (like mockImplementation, mockReset, etc.) work as expected.
+ */
+const vitestMockFunctionKeys = new Set([
+  'getMockName',
+  'mock',
+  'mockClear',
+  'mockImplementation',
+  'mockImplementationOnce',
+  'mockName',
+  'mockRejectedValue',
+  'mockRejectedValueOnce',
+  'mockReset',
+  'mockResolvedValue',
+  'mockResolvedValueOnce',
+  'mockRestore',
+  'mockReturnThis',
+  'mockReturnValue',
+  'mockReturnValueOnce',
+  'withImplementation',
+  'calls',
+]);
 
-export type PartialFuncReturn<T> = {
-  [K in keyof T]?: T[K] extends (...args: infer A) => infer U
-    ? (...args: A) => PartialFuncReturn<U>
-    : DeepPartial<T[K]>;
-};
-
-export type DeepMocked<T> = {
-  [K in keyof T]: Required<T>[K] extends (...args: any[]) => infer U
-    ? MockInstance<ArgumentsType<T[K]>, ReturnType<Required<T>[K]>> &
-        ((...args: ArgumentsType<T[K]>) => DeepMocked<U>)
-    : T[K];
-} & T;
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const createRecursiveMockProxy = (_name: string) => {
+/**
+ * Creates a Proxy that enables deep mocking with automatic property generation.
+ *
+ * @param name - Debug name for the mock (used in error messages)
+ * @param strict - If true, throws errors when calling unstubbed methods
+ * @param base - Optional base object with pre-defined properties/implementations
+ * @returns A proxied object that auto-generates mocks for any accessed property
+ */
+const createProxy: {
+  <T extends object>(name: string, strict: boolean, base: T): T;
+  <T extends Mock = Mock>(name: string, strict: boolean): T;
+} = <T extends object | Mock>(name: string, strict: boolean, base?: T): T => {
   const cache = new Map<string | number | symbol, any>();
 
-  const proxy = new Proxy(
-    {},
-    {
-      get: (obj, prop) => {
-        const propName = prop.toString();
-        if (cache.has(prop)) {
-          return cache.get(prop);
-        }
+  const handler: ProxyHandler<T> = {
+    get: (obj, prop, receiver) => {
+      const propName = prop.toString();
 
-        const checkProp = obj[prop];
-
-        const mockedProp =
-          prop in obj
-            ? typeof checkProp === 'function'
-              ? vi.fn()
-              : checkProp
-            : propName === 'then'
-              ? undefined
-              : createRecursiveMockProxy(propName);
-
-        cache.set(prop, mockedProp);
-
-        return mockedProp;
-      },
-    },
-  );
-
-  return vi.fn(() => proxy);
-};
-
-export type MockOptions = {
-  name?: string;
-};
-
-export const createMock = <T extends object>(
-  partial: PartialFuncReturn<T> = {},
-  options: MockOptions = {},
-): DeepMocked<T> => {
-  const cache = new Map<string | number | symbol, any>();
-  const { name = 'mock' } = options;
-
-  const proxy = new Proxy(partial, {
-    get: (obj, prop) => {
+      // Return undefined for special properties to prevent interference:
+      // - 'inspect' & Symbol(util.inspect.custom): Node.js inspection (console.log)
+      // - 'then': Prevents mocks from being treated as Promises
+      // - 'asymmetricMatch': Prevents interference with Vitest's asymmetric matchers
       if (
         prop === 'inspect' ||
         prop === 'then' ||
-        (typeof prop === 'symbol' &&
-          prop.toString() === 'Symbol(util.inspect.custom)')
+        prop === 'asymmetricMatch' ||
+        (typeof prop === 'symbol' && propName === 'Symbol(util.inspect.custom)')
       ) {
         return undefined;
       }
 
+      // For auto-mocked functions (no base), allow direct access to Vitest Mock API properties
+      // This ensures methods like mockImplementation work correctly
+      if (!base && vitestMockFunctionKeys.has(propName)) {
+        return Reflect.get(obj, prop, receiver);
+      }
+
+      // Return cached value if we've already created a mock for this property
+      // Ensures consistency: accessing mock.foo twice returns the same mock
       if (cache.has(prop)) {
         return cache.get(prop);
       }
 
-      const checkProp = obj[prop];
+      const checkProp = (obj as any)[prop];
 
       let mockedProp: any;
 
       if (prop in obj) {
-        mockedProp =
-          typeof checkProp === 'function' ? vi.fn(checkProp) : checkProp;
-      } else if (prop === 'constructor') {
-        mockedProp = () => undefined;
+        // Property exists in the base object
+        // Check for functions - don't double-wrap already mocked functions
+        if (typeof checkProp === 'function') {
+          // If it's already a vi.fn() mock (from mock composition), use it as-is
+          // Otherwise wrap it with vi.fn() to track calls
+          mockedProp = vi.isMockFunction(checkProp)
+            ? checkProp
+            : vi.fn(checkProp);
+        } else {
+          // Non-function property, use the value directly
+          mockedProp = checkProp;
+        }
       } else {
-        mockedProp = createRecursiveMockProxy(`${name}.${prop.toString()}`);
+        // Property doesn't exist - auto-generate a nested mock
+        // This enables deep access like mock.nested.deeply.whatever
+        mockedProp = createProxy(`${name}.${propName}`, strict);
       }
 
+      // Cache the mocked property for consistent return values
       cache.set(prop, mockedProp);
+
       return mockedProp;
     },
-  });
+    set: (obj, prop, newValue) => {
+      // Update both the cache and the underlying object
+      // This allows mock properties to be reassigned: mock.foo = 42
+      cache.set(prop, newValue);
 
-  return proxy as DeepMocked<T>;
+      return Reflect.set(obj, prop, newValue);
+    },
+  };
+
+  // For auto-mocked functions (no base), add apply trap to handle function calls
+  if (!base) {
+    (handler as ProxyHandler<Mock>).apply = (target, thisArg, argsArray) => {
+      const result = Reflect.apply(target, thisArg, argsArray);
+
+      // If the function has a user-provided implementation or returned a value, use it
+      if (target.getMockImplementation() || result !== undefined) {
+        return result;
+      }
+
+      // Strict mode: throw error if function is called without being stubbed
+      if (strict) {
+        throw new Error(
+          `Method ${name} was called without being explicitly stubbed`,
+        );
+      }
+
+      // Auto-generate a mock for the return value
+      // Cache it so repeated calls return the same mock object
+      if (!cache.has('__apply')) {
+        cache.set('__apply', createProxy(name, strict));
+      }
+
+      return cache.get('__apply');
+    };
+  }
+  return new Proxy(base || (vi.fn() as T), handler);
+};
+
+export type MockOptions = {
+  /**
+   * Debug name for the mock, used in error messages
+   *
+   * @default mock
+   */
+  name?: string;
+  /**
+   * If true, throws errors when calling unstubbed methods
+   *
+   * @default false
+   */
+  strict?: boolean;
+};
+
+/**
+ * Creates a deep mock of the specified type with Vitest.
+ *
+ * Features:
+ * - All properties and methods are automatically mocked
+ * - Nested properties are also deeply mocked (e.g., `mock.user.address.city`)
+ * - Function return values are automatically mocked and awaitable
+ * - Supports mock composition: pass existing mocks as partial values
+ * - All functions are Vitest mocks with full Mock API support
+ *
+ * @param partial - Optional object with pre-defined properties/implementations
+ * @param options - Optional configuration (name, strict mode)
+ * @returns A deeply mocked version of T with all Mock methods available
+ *
+ * @example
+ * ```typescript
+ * interface User {
+ *   getName: () => string;
+ *   getAddress: () => { city: string };
+ * }
+ *
+ * // Auto-mocked
+ * const user = createMock<User>();
+ * user.getName.mockReturnValue('John');
+ * user.getAddress().city; // Automatically mocked
+ *
+ * // With partial implementation
+ * const user = createMock<User>({
+ *   getName: () => 'John'
+ * });
+ *
+ * // Mock composition
+ * const address = createMock<Address>({ city: 'NYC' });
+ * const user = createMock<User>({
+ *   getAddress: () => address
+ * });
+ * ```
+ */
+export const createMock = <T extends object>(
+  partial: PartialMockInput<T> = {},
+  options: MockOptions = {},
+): DeepMockedType<T> => {
+  const { name = 'mock', strict = false } = options;
+  const proxy = createProxy<T>(name, strict, partial as T);
+
+  return proxy as DeepMockedType<T>;
 };

--- a/packages/testing/ts-vitest/src/mocks.ts
+++ b/packages/testing/ts-vitest/src/mocks.ts
@@ -1,6 +1,6 @@
 import type { Mock } from 'vitest';
 import { vi } from 'vitest';
-import { DeepMockedType, PartialMockInput } from './type-helper.js';
+import { DeepMocked, PartialFuncReturn } from './type-helper.js';
 
 /**
  * Set of property names that are part of Vitest's Mock function API. These keys are handled directly by the underlying vi.fn() mock instance and should not be intercepted by our proxy. This ensures that all Vitest mock methods (like mockImplementation, mockReset, etc.) work as expected.
@@ -188,11 +188,11 @@ export type MockOptions = {
  * ```
  */
 export const createMock = <T extends object>(
-  partial: PartialMockInput<T> = {},
+  partial: PartialFuncReturn<T> = {},
   options: MockOptions = {},
-): DeepMockedType<T> => {
+): DeepMocked<T> => {
   const { name = 'mock', strict = false } = options;
   const proxy = createProxy<T>(name, strict, partial as T);
 
-  return proxy as DeepMockedType<T>;
+  return proxy as DeepMocked<T>;
 };

--- a/packages/testing/ts-vitest/src/type-helper.ts
+++ b/packages/testing/ts-vitest/src/type-helper.ts
@@ -23,10 +23,10 @@ export type DeepPartial<T> = {
  * - Non-function properties can be partial values OR already-mocked DeepMocked objects
  * This dual support prevents double-wrapping and allows flexible mock composition.
  */
-export type PartialMockInput<T> = {
+export type PartialFuncReturn<T> = {
   [K in keyof T]?: T[K] extends (...args: infer A) => infer U
-    ? ((...args: A) => PartialMockInput<U>) | DeepMockedType<T[K]>
-    : DeepPartial<T[K]> | DeepMockedType<T[K]>;
+    ? ((...args: A) => PartialFuncReturn<U>) | DeepMocked<T[K]>
+    : DeepPartial<T[K]> | DeepMocked<T[K]>;
 };
 
 /**
@@ -43,7 +43,7 @@ export type IsExactlyUnknown<T> = unknown extends T
  */
 export type DeepMockedFunction<T extends (...args: any[]) => any> = ((
   ...args: Parameters<T>
-) => DeepMockedType<ReturnType<T>>) &
+) => DeepMocked<ReturnType<T>>) &
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   Mock<Parameters<T>>;
@@ -70,7 +70,7 @@ export type DeepMockedFunction<T extends (...args: any[]) => any> = ((
  * 4. Primitives (string, number, boolean, etc.):
  *    - Left as-is since they can't have nested properties
  */
-export type DeepMockedType<T> = {
+export type DeepMocked<T> = {
   [K in keyof T]: IsExactlyUnknown<T[K]> extends true
     ? any
     : NonNullable<T[K]> extends (...args: any[]) => any
@@ -79,7 +79,7 @@ export type DeepMockedType<T> = {
         : DeepMockedFunction<NonNullable<T[K]>>
       : NonNullable<T[K]> extends object
         ? undefined extends T[K]
-          ? DeepMockedType<NonNullable<T[K]>> | undefined
-          : DeepMockedType<T[K]>
+          ? DeepMocked<NonNullable<T[K]>> | undefined
+          : DeepMocked<T[K]>
         : T[K]; // primitive
 };

--- a/packages/testing/ts-vitest/src/type-helper.ts
+++ b/packages/testing/ts-vitest/src/type-helper.ts
@@ -1,0 +1,83 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+import type { Mock } from 'vitest';
+
+/**
+ * Recursively makes all properties of a type optional and applies the same transformation
+ * to nested objects. Arrays are preserved but their elements are made deeply partial.
+ * Unknown types are left as-is since we can't make assumptions about their structure.
+ */
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends Array<infer U>
+    ? Array<DeepPartial<U>>
+    : T[P] extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartial<U>>
+      : unknown extends T[P]
+        ? T[P]
+        : DeepPartial<T[P]>;
+};
+
+/**
+ * Type for the partial object passed to createMock. All properties are optional.
+ * - Functions can be provided as implementations OR as already-mocked DeepMocked functions
+ *   (enabling mock composition - passing pre-built mocks to other mocks)
+ * - Non-function properties can be partial values OR already-mocked DeepMocked objects
+ * This dual support prevents double-wrapping and allows flexible mock composition.
+ */
+export type PartialMockInput<T> = {
+  [K in keyof T]?: T[K] extends (...args: infer A) => infer U
+    ? ((...args: A) => PartialMockInput<U>) | DeepMockedType<T[K]>
+    : DeepPartial<T[K]> | DeepMockedType<T[K]>;
+};
+
+/**
+ * Detects if a type is exactly `unknown` (not `any` or other types).
+ */
+export type IsExactlyUnknown<T> = unknown extends T
+  ? T extends {}
+    ? false
+    : true
+  : false;
+
+/**
+ * Helper type for mocked functions with deep mocked return types.
+ */
+export type DeepMockedFunction<T extends (...args: any[]) => any> = ((
+  ...args: Parameters<T>
+) => DeepMockedType<ReturnType<T>>) &
+  Mock<Parameters<T>, ReturnType<T>>;
+
+/**
+ * Recursively transforms a type into a deeply mocked version.
+ * Each property is handled based on its type:
+ *
+ * 1. Unknown types (e.g., Record<string, unknown>):
+ *    - Become `any` to support dynamic proxy access
+ *    - Enables `mock.anything.nested.deeply` without type errors
+ *
+ * 2. Functions:
+ *    - Wrapped with DeepMockedFunction to provide Mock methods
+ *    - Return types are recursively DeepMockedType
+ *    - Optional functions preserve their optionality (union with undefined)
+ *    - Example: `mock.getUser()` returns DeepMockedType<User> with all Mock methods
+ *
+ * 3. Objects:
+ *    - Recursively transformed to DeepMockedType
+ *    - Optional objects preserve their optionality
+ *    - Example: `mock.nested.property` is also deeply mocked
+ *
+ * 4. Primitives (string, number, boolean, etc.):
+ *    - Left as-is since they can't have nested properties
+ */
+export type DeepMockedType<T> = {
+  [K in keyof T]: IsExactlyUnknown<T[K]> extends true
+    ? any
+    : NonNullable<T[K]> extends (...args: any[]) => any
+      ? undefined extends T[K]
+        ? DeepMockedFunction<NonNullable<T[K]>> | undefined
+        : DeepMockedFunction<NonNullable<T[K]>>
+      : NonNullable<T[K]> extends object
+        ? undefined extends T[K]
+          ? DeepMockedType<NonNullable<T[K]>> | undefined
+          : DeepMockedType<T[K]>
+        : T[K]; // primitive
+};

--- a/packages/testing/ts-vitest/src/type-helper.ts
+++ b/packages/testing/ts-vitest/src/type-helper.ts
@@ -44,7 +44,9 @@ export type IsExactlyUnknown<T> = unknown extends T
 export type DeepMockedFunction<T extends (...args: any[]) => any> = ((
   ...args: Parameters<T>
 ) => DeepMockedType<ReturnType<T>>) &
-  Mock<Parameters<T>, ReturnType<T>>;
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  Mock<Parameters<T>>;
 
 /**
  * Recursively transforms a type into a deeply mocked version.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,11 +122,11 @@ importers:
         version: 1.6.3(@algolia/client-search@5.18.0)(@types/node@22.16.5)(axios@1.7.9)(postcss@8.5.6)(search-insights@2.17.3)(terser@5.44.1)(typescript@5.9.3)
     optionalDependencies:
       '@vitest/coverage-v8':
-        specifier: ^1.6.1
-        version: 1.6.1(vitest@1.6.1(@types/node@22.16.5)(jsdom@16.7.0)(terser@5.44.1))
+        specifier: ^4.0.16
+        version: 4.0.16(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.16.5)(jiti@2.4.2)(jsdom@16.7.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.0))
       vitest:
-        specifier: ^1.6.1
-        version: 1.6.1(@types/node@22.16.5)(jsdom@16.7.0)(terser@5.44.1)
+        specifier: ^4.0.16
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.16.5)(jiti@2.4.2)(jsdom@16.7.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.0)
 
   integration/google-cloud-pubsub:
     dependencies:
@@ -573,8 +573,16 @@ packages:
     resolution: {integrity: sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.25.7':
     resolution: {integrity: sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.25.7':
@@ -591,6 +599,11 @@ packages:
 
   '@babel/parser@7.25.7':
     resolution: {integrity: sha512-aZn7ETtQsjjGG5HruveUK06cU3Hljuhd9Iojm4M8WWv3wLE6OkE5PWbDUkItmMgegmccaITudyuW5RPYrYlgWw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.28.5':
+    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -695,8 +708,16 @@ packages:
     resolution: {integrity: sha512-vwIVdXG+j+FOpkwqHRcBgHLYNL7XMkufrlaFvL9o6Ai9sJn9+PdyIL5qa0XzTZw084c+u9LOls53eoZWP/W5WQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/types@7.28.5':
+    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+    engines: {node: '>=6.9.0'}
+
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -1635,6 +1656,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
@@ -2435,13 +2459,14 @@ packages:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
 
-  '@vitest/coverage-v8@1.6.1':
-    resolution: {integrity: sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==}
+  '@vitest/coverage-v8@4.0.16':
+    resolution: {integrity: sha512-2rNdjEIsPRzsdu6/9Eq0AYAzYdpP6Bx9cje9tL3FE5XzXRQF1fNU9pe/1yE8fCrS0HD+fBtt6gLPh6LI57tX7A==}
     peerDependencies:
-      vitest: 1.6.1
-
-  '@vitest/expect@1.6.1':
-    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
+      '@vitest/browser': 4.0.16
+      vitest: 4.0.16
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
 
   '@vitest/expect@4.0.16':
     resolution: {integrity: sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==}
@@ -2460,26 +2485,14 @@ packages:
   '@vitest/pretty-format@4.0.16':
     resolution: {integrity: sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==}
 
-  '@vitest/runner@1.6.1':
-    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
-
   '@vitest/runner@4.0.16':
     resolution: {integrity: sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==}
-
-  '@vitest/snapshot@1.6.1':
-    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
 
   '@vitest/snapshot@4.0.16':
     resolution: {integrity: sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==}
 
-  '@vitest/spy@1.6.1':
-    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
-
   '@vitest/spy@4.0.16':
     resolution: {integrity: sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==}
-
-  '@vitest/utils@1.6.1':
-    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
 
   '@vitest/utils@4.0.16':
     resolution: {integrity: sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==}
@@ -2837,12 +2850,12 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
-  assertion-error@1.1.0:
-    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
-
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.9:
+    resolution: {integrity: sha512-dSC6tJeOJxbZrPzPbv5mMd6CMiQ1ugaVXXPRad2fXUSsy1kstFn9XQWemV9VW7Y7kpxgQ/4WMoZfwdH8XSU48w==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -2974,10 +2987,6 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
   cacache@18.0.4:
     resolution: {integrity: sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -3019,10 +3028,6 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
-  chai@4.5.0:
-    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
-    engines: {node: '>=4'}
-
   chai@6.2.1:
     resolution: {integrity: sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==}
     engines: {node: '>=18'}
@@ -3058,9 +3063,6 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
-
-  check-error@1.0.3:
-    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -3220,9 +3222,6 @@ packages:
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
     engines: {'0': node >= 6.0}
-
-  confbox@0.1.7:
-    resolution: {integrity: sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==}
 
   consola@3.4.0:
     resolution: {integrity: sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==}
@@ -3434,10 +3433,6 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
-
-  deep-eql@4.1.4:
-    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
-    engines: {node: '>=6'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -3779,10 +3774,6 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
-  execa@8.0.1:
-    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
-    engines: {node: '>=16.17'}
-
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
@@ -4028,9 +4019,6 @@ packages:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
 
-  get-func-name@2.0.2:
-    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
-
   get-intrinsic@1.2.7:
     resolution: {integrity: sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==}
     engines: {node: '>= 0.4'}
@@ -4059,10 +4047,6 @@ packages:
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
-
-  get-stream@8.0.1:
-    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
-    engines: {node: '>=16'}
 
   get-tsconfig@4.8.1:
     resolution: {integrity: sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==}
@@ -4296,10 +4280,6 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
 
-  human-signals@5.0.0:
-    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
-    engines: {node: '>=16.17.0'}
-
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
@@ -4497,10 +4477,6 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
-  is-stream@3.0.0:
-    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   is-text-path@1.0.1:
     resolution: {integrity: sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==}
     engines: {node: '>=0.10.0'}
@@ -4567,6 +4543,10 @@ packages:
 
   istanbul-reports@3.1.7:
     resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
+    engines: {node: '>=8'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
   iterare@1.2.1:
@@ -4742,8 +4722,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-tokens@9.0.0:
-    resolution: {integrity: sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==}
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -4907,10 +4887,6 @@ packages:
     resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
     engines: {node: '>=6.11.5'}
 
-  local-pkg@0.5.0:
-    resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
-    engines: {node: '>=14'}
-
   locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
     engines: {node: '>=4'}
@@ -4985,9 +4961,6 @@ packages:
     resolution: {integrity: sha512-Ajzxb8CM6WAnFjgiloPsI3bF+WCxcvhdIG3KNA2KN962+tdBsHcuQ4k4qX/EcS/2CRkcc0iAkR956Nib6aXU/Q==}
     engines: {node: '>=0.10.0'}
 
-  loupe@2.3.7:
-    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
-
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -5011,8 +4984,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.3.5:
-    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+  magicast@0.5.1:
+    resolution: {integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==}
 
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -5140,10 +5113,6 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
-  mimic-fn@4.0.0:
-    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
-    engines: {node: '>=12'}
-
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
@@ -5246,9 +5215,6 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
-
-  mlly@1.7.1:
-    resolution: {integrity: sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==}
 
   modify-values@1.0.1:
     resolution: {integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==}
@@ -5406,10 +5372,6 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
-  npm-run-path@5.3.0:
-    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   nwsapi@2.2.13:
     resolution: {integrity: sha512-cTGB9ptp9dY9A5VbMSe7fQBcl/tt22Vcqdq8+eN93rblOuE0aCFu4aZ2vMwct/2t+lFnosm8RkQW1I0Omb1UtQ==}
 
@@ -5450,10 +5412,6 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
-
-  onetime@6.0.0:
-    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
-    engines: {node: '>=12'}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -5505,10 +5463,6 @@ packages:
   p-limit@4.0.0:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  p-limit@5.0.0:
-    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
-    engines: {node: '>=18'}
 
   p-locate@2.0.0:
     resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
@@ -5623,10 +5577,6 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
-
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -5650,14 +5600,8 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
-
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pathval@1.1.1:
-    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   peek-readable@7.0.0:
     resolution: {integrity: sha512-nri2TO5JE3/mRryik9LlHFT53cgHfRK0Lt0BAZQXku/AW3E6XLt2GaY8siWi7dvW/m1z0ecn+J+bpDa9ZN3IsQ==}
@@ -5748,9 +5692,6 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
-
-  pkg-types@1.2.0:
-    resolution: {integrity: sha512-+ifYuSSqOQ8CqP4MbZA5hDpb97n3E8SVWdJe+Wms9kj745lmd3b7EZJiqvmLwAlmRfjrI7Hi5z3kdBJ93lFNPA==}
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -6301,9 +6242,6 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
-  std-env@3.7.0:
-    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
-
   stream-events@1.0.5:
     resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
 
@@ -6363,10 +6301,6 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
-  strip-final-newline@3.0.0:
-    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
-    engines: {node: '>=12'}
-
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
@@ -6374,9 +6308,6 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
-
-  strip-literal@2.1.0:
-    resolution: {integrity: sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==}
 
   stripe@20.0.0:
     resolution: {integrity: sha512-EaZeWpbJOCcDytdjKSwdrL5BxzbDGNueiCfHjHXlPdBQvLqoxl6AAivC35SPzTmVXJb5duXQlXFGS45H0+e6Gg==}
@@ -6534,16 +6465,8 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@0.8.4:
-    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
-    engines: {node: '>=14.0.0'}
-
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@2.2.1:
-    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
 
   tmp@0.0.33:
@@ -6722,9 +6645,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ufo@1.5.4:
-    resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
-
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
@@ -6839,11 +6759,6 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite-node@1.6.1:
-    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-
   vite@5.4.14:
     resolution: {integrity: sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -6925,31 +6840,6 @@ packages:
       markdown-it-mathjax3:
         optional: true
       postcss:
-        optional: true
-
-  vitest@1.6.1:
-    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 1.6.1
-      '@vitest/ui': 1.6.1
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
         optional: true
 
   vitest@4.0.16:
@@ -7456,7 +7346,13 @@ snapshots:
 
   '@babel/helper-string-parser@7.25.7': {}
 
+  '@babel/helper-string-parser@7.27.1':
+    optional: true
+
   '@babel/helper-validator-identifier@7.25.7': {}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    optional: true
 
   '@babel/helper-validator-option@7.25.7': {}
 
@@ -7475,6 +7371,11 @@ snapshots:
   '@babel/parser@7.25.7':
     dependencies:
       '@babel/types': 7.25.7
+
+  '@babel/parser@7.28.5':
+    dependencies:
+      '@babel/types': 7.28.5
+    optional: true
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.25.7)':
     dependencies:
@@ -7584,7 +7485,16 @@ snapshots:
       '@babel/helper-validator-identifier': 7.25.7
       to-fast-properties: 2.0.0
 
+  '@babel/types@7.28.5':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+    optional: true
+
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@bcoe/v8-coverage@1.0.2':
+    optional: true
 
   '@colors/colors@1.5.0':
     optional: true
@@ -8512,6 +8422,12 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+    optional: true
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
@@ -9491,31 +9407,22 @@ snapshots:
       vite: 5.4.14(@types/node@22.16.5)(terser@5.44.1)
       vue: 3.5.13(typescript@5.9.3)
 
-  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@22.16.5)(jsdom@16.7.0)(terser@5.44.1))':
+  '@vitest/coverage-v8@4.0.16(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.16.5)(jiti@2.4.2)(jsdom@16.7.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.0))':
     dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 0.2.3
-      debug: 4.4.0
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.16
+      ast-v8-to-istanbul: 0.3.9
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
-      istanbul-reports: 3.1.7
-      magic-string: 0.30.11
-      magicast: 0.3.5
-      picocolors: 1.1.1
-      std-env: 3.7.0
-      strip-literal: 2.1.0
-      test-exclude: 6.0.0
-      vitest: 1.6.1(@types/node@22.16.5)(jsdom@16.7.0)(terser@5.44.1)
+      istanbul-reports: 3.2.0
+      magicast: 0.5.1
+      obug: 2.1.1
+      std-env: 3.10.0
+      tinyrainbow: 3.0.3
+      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.16.5)(jiti@2.4.2)(jsdom@16.7.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
-    optional: true
-
-  '@vitest/expect@1.6.1':
-    dependencies:
-      '@vitest/spy': 1.6.1
-      '@vitest/utils': 1.6.1
-      chai: 4.5.0
     optional: true
 
   '@vitest/expect@4.0.16':
@@ -9539,24 +9446,10 @@ snapshots:
     dependencies:
       tinyrainbow: 3.0.3
 
-  '@vitest/runner@1.6.1':
-    dependencies:
-      '@vitest/utils': 1.6.1
-      p-limit: 5.0.0
-      pathe: 1.1.2
-    optional: true
-
   '@vitest/runner@4.0.16':
     dependencies:
       '@vitest/utils': 4.0.16
       pathe: 2.0.3
-
-  '@vitest/snapshot@1.6.1':
-    dependencies:
-      magic-string: 0.30.11
-      pathe: 1.1.2
-      pretty-format: 29.7.0
-    optional: true
 
   '@vitest/snapshot@4.0.16':
     dependencies:
@@ -9564,20 +9457,7 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@1.6.1':
-    dependencies:
-      tinyspy: 2.2.1
-    optional: true
-
   '@vitest/spy@4.0.16': {}
-
-  '@vitest/utils@1.6.1':
-    dependencies:
-      diff-sequences: 29.6.3
-      estree-walker: 3.0.3
-      loupe: 2.3.7
-      pretty-format: 29.7.0
-    optional: true
 
   '@vitest/utils@4.0.16':
     dependencies:
@@ -9810,7 +9690,7 @@ snapshots:
 
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.14.0
+      acorn: 8.15.0
     optional: true
 
   acorn@7.4.1: {}
@@ -9968,10 +9848,14 @@ snapshots:
 
   asap@2.0.6: {}
 
-  assertion-error@1.1.0:
-    optional: true
-
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.9:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 9.0.1
+    optional: true
 
   async@3.2.6: {}
 
@@ -10143,9 +10027,6 @@ snapshots:
 
   bytes@3.1.2: {}
 
-  cac@6.7.14:
-    optional: true
-
   cacache@18.0.4:
     dependencies:
       '@npmcli/fs': 3.1.1
@@ -10191,17 +10072,6 @@ snapshots:
 
   ccount@2.0.1: {}
 
-  chai@4.5.0:
-    dependencies:
-      assertion-error: 1.1.0
-      check-error: 1.0.3
-      deep-eql: 4.1.4
-      get-func-name: 2.0.2
-      loupe: 2.3.7
-      pathval: 1.1.1
-      type-detect: 4.1.0
-    optional: true
-
   chai@6.2.1: {}
 
   chalk@2.4.2:
@@ -10231,11 +10101,6 @@ snapshots:
   chardet@0.7.0: {}
 
   chardet@2.1.1: {}
-
-  check-error@1.0.3:
-    dependencies:
-      get-func-name: 2.0.2
-    optional: true
 
   chokidar@3.6.0:
     dependencies:
@@ -10400,9 +10265,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
       typedarray: 0.0.6
-
-  confbox@0.1.7:
-    optional: true
 
   consola@3.4.0: {}
 
@@ -10610,11 +10472,6 @@ snapshots:
   dedent@0.7.0: {}
 
   dedent@1.5.3: {}
-
-  deep-eql@4.1.4:
-    dependencies:
-      type-detect: 4.1.0
-    optional: true
 
   deep-is@0.1.4: {}
 
@@ -11005,19 +10862,6 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
-  execa@8.0.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      get-stream: 8.0.1
-      human-signals: 5.0.0
-      is-stream: 3.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 5.3.0
-      onetime: 6.0.0
-      signal-exit: 4.1.0
-      strip-final-newline: 3.0.0
-    optional: true
-
   exit@0.1.2: {}
 
   expand-tilde@2.0.2:
@@ -11320,9 +11164,6 @@ snapshots:
 
   get-east-asian-width@1.3.0: {}
 
-  get-func-name@2.0.2:
-    optional: true
-
   get-intrinsic@1.2.7:
     dependencies:
       call-bind-apply-helpers: 1.0.1
@@ -11355,9 +11196,6 @@ snapshots:
   get-stream@6.0.0: {}
 
   get-stream@6.0.1: {}
-
-  get-stream@8.0.1:
-    optional: true
 
   get-tsconfig@4.8.1:
     dependencies:
@@ -11675,9 +11513,6 @@ snapshots:
 
   human-signals@2.1.0: {}
 
-  human-signals@5.0.0:
-    optional: true
-
   husky@9.1.7: {}
 
   iconv-lite@0.4.24:
@@ -11886,9 +11721,6 @@ snapshots:
 
   is-stream@2.0.1: {}
 
-  is-stream@3.0.0:
-    optional: true
-
   is-text-path@1.0.1:
     dependencies:
       text-extensions: 1.9.0
@@ -11958,6 +11790,12 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+    optional: true
 
   iterare@1.2.1: {}
 
@@ -12420,7 +12258,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-tokens@9.0.0:
+  js-tokens@9.0.1:
     optional: true
 
   js-yaml@3.14.1:
@@ -12705,12 +12543,6 @@ snapshots:
 
   loader-runner@4.3.1: {}
 
-  local-pkg@0.5.0:
-    dependencies:
-      mlly: 1.7.1
-      pkg-types: 1.2.0
-    optional: true
-
   locate-path@2.0.0:
     dependencies:
       p-locate: 2.0.0
@@ -12773,11 +12605,6 @@ snapshots:
 
   longest@2.0.1: {}
 
-  loupe@2.3.7:
-    dependencies:
-      get-func-name: 2.0.2
-    optional: true
-
   lru-cache@10.4.3: {}
 
   lru-cache@11.0.2: {}
@@ -12802,10 +12629,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.3.5:
+  magicast@0.5.1:
     dependencies:
-      '@babel/parser': 7.25.7
-      '@babel/types': 7.25.7
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
       source-map-js: 1.2.1
     optional: true
 
@@ -12939,9 +12766,6 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  mimic-fn@4.0.0:
-    optional: true
-
   mimic-function@5.0.1: {}
 
   min-indent@1.0.1: {}
@@ -13036,14 +12860,6 @@ snapshots:
       minimist: 1.2.8
 
   mkdirp@1.0.4: {}
-
-  mlly@1.7.1:
-    dependencies:
-      acorn: 8.15.0
-      pathe: 1.1.2
-      pkg-types: 1.2.0
-      ufo: 1.5.4
-    optional: true
 
   modify-values@1.0.1: {}
 
@@ -13218,11 +13034,6 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
-  npm-run-path@5.3.0:
-    dependencies:
-      path-key: 4.0.0
-    optional: true
-
   nwsapi@2.2.13: {}
 
   nx@20.3.0:
@@ -13295,11 +13106,6 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  onetime@6.0.0:
-    dependencies:
-      mimic-fn: 4.0.0
-    optional: true
-
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
@@ -13369,11 +13175,6 @@ snapshots:
   p-limit@4.0.0:
     dependencies:
       yocto-queue: 1.1.1
-
-  p-limit@5.0.0:
-    dependencies:
-      yocto-queue: 1.1.1
-    optional: true
 
   p-locate@2.0.0:
     dependencies:
@@ -13489,9 +13290,6 @@ snapshots:
 
   path-key@3.1.1: {}
 
-  path-key@4.0.0:
-    optional: true
-
   path-parse@1.0.7: {}
 
   path-scurry@1.11.1:
@@ -13512,13 +13310,7 @@ snapshots:
 
   path-type@4.0.0: {}
 
-  pathe@1.1.2:
-    optional: true
-
   pathe@2.0.3: {}
-
-  pathval@1.1.1:
-    optional: true
 
   peek-readable@7.0.0: {}
 
@@ -13584,13 +13376,6 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
-
-  pkg-types@1.2.0:
-    dependencies:
-      confbox: 0.1.7
-      mlly: 1.7.1
-      pathe: 1.1.2
-    optional: true
 
   pluralize@8.0.0: {}
 
@@ -14173,9 +13958,6 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  std-env@3.7.0:
-    optional: true
-
   stream-events@1.0.5:
     dependencies:
       stubs: 3.0.0
@@ -14236,19 +14018,11 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
-  strip-final-newline@3.0.0:
-    optional: true
-
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
-
-  strip-literal@2.1.0:
-    dependencies:
-      js-tokens: 9.0.0
-    optional: true
 
   stripe@20.0.0(@types/node@22.16.5):
     dependencies:
@@ -14424,13 +14198,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  tinypool@0.8.4:
-    optional: true
-
   tinyrainbow@3.0.3: {}
-
-  tinyspy@2.2.1:
-    optional: true
 
   tmp@0.0.33:
     dependencies:
@@ -14623,9 +14391,6 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  ufo@1.5.4:
-    optional: true
-
   uglify-js@3.19.3:
     optional: true
 
@@ -14735,25 +14500,6 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@1.6.1(@types/node@22.16.5)(terser@5.44.1):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1(supports-color@5.5.0)
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      vite: 5.4.14(@types/node@22.16.5)(terser@5.44.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    optional: true
-
   vite@5.4.14(@types/node@22.16.5)(terser@5.44.1):
     dependencies:
       esbuild: 0.21.5
@@ -14828,42 +14574,6 @@ snapshots:
       - terser
       - typescript
       - universal-cookie
-
-  vitest@1.6.1(@types/node@22.16.5)(jsdom@16.7.0)(terser@5.44.1):
-    dependencies:
-      '@vitest/expect': 1.6.1
-      '@vitest/runner': 1.6.1
-      '@vitest/snapshot': 1.6.1
-      '@vitest/spy': 1.6.1
-      '@vitest/utils': 1.6.1
-      acorn-walk: 8.3.4
-      chai: 4.5.0
-      debug: 4.4.0
-      execa: 8.0.1
-      local-pkg: 0.5.0
-      magic-string: 0.30.11
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      std-env: 3.7.0
-      strip-literal: 2.1.0
-      tinybench: 2.9.0
-      tinypool: 0.8.4
-      vite: 5.4.14(@types/node@22.16.5)(terser@5.44.1)
-      vite-node: 1.6.1(@types/node@22.16.5)(terser@5.44.1)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 22.16.5
-      jsdom: 16.7.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    optional: true
 
   vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.16.5)(jiti@2.4.2)(jsdom@16.7.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.0):
     dependencies:


### PR DESCRIPTION
### Improvements
- `@golevelup/ts-vitest` is now running on the latest vitest version with a fully compatible API
- `vitest` was upgraded from v1.61 to 4.0.16, please feel free to review Vitest changelogs

### Breaking changes
- Some types were adjusted based on the new Vitest API changes
