### PR TITLE
fix(ts-vitest): correct DeepMocked type definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Build
         run: pnpm build --concurrency=12
 
+      - name: Lint & Typecheck
+        run: pnpm lint && pnpm lerna:typecheck
+
       - name: Run unit tests
         run: pnpm test:ci
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "lerna:version": "lerna version --no-private",
     "lerna:publish": "lerna run build && pnpm test && lerna publish from-package --no-private -m 'chore: publish'",
     "lerna:prerelease": "lerna run build && pnpm test && lerna publish prerelease --preid rc -m 'chore: publish prerelease'",
+    "lerna:typecheck": "lerna run typecheck",
     "build": " lerna run build --ignore rabbitmq-integration --ignore google-cloud-pubsub-integration",
     "copy-readme": "lerna run copy-readme",
     "build:watch": "lerna run --parallel build:watch --ignore rabbitmq-integration --ignore google-cloud-pubsub-integration",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -24,7 +24,8 @@
     "copy-readme": "cp ../../docs/common.md ./README.md",
     "build": "tsc --build tsconfig.build.json",
     "build:watch": "tsc --build tsconfig.build.json --watch",
-    "test": "jest"
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
   },
   "bugs": {
     "url": "https://github.com/golevelup/nestjs/issues"

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -29,7 +29,8 @@
     "copy-readme": "cp ../../docs/discovery.md ./README.md",
     "build": "tsc --build tsconfig.build.json",
     "build:watch": "tsc --build tsconfig.build.json --watch",
-    "test": "jest"
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "lodash": "^4.17.21"

--- a/packages/google-cloud-pubsub/package.json
+++ b/packages/google-cloud-pubsub/package.json
@@ -28,7 +28,8 @@
     "copy-readme": "cp ../../docs/modules/google-pubsub.md ./README.md",
     "build": "tsc --build tsconfig.build.json",
     "build:watch": "tsc --build tsconfig.build.json --watch",
-    "test": "jest"
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
   },
   "bugs": {
     "url": "https://github.com/golevelup/nestjs/issues"

--- a/packages/graphile-worker/package.json
+++ b/packages/graphile-worker/package.json
@@ -40,7 +40,8 @@
     "copy-readme": "cp ../../docs/modules/graphile-worker.md ./README2.md",
     "build": "tsc --build tsconfig.build.json",
     "build:watch": "tsc --build tsconfig.build.json --watch",
-    "test": "vitest"
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "bugs": {
     "url": "https://github.com/golevelup/nestjs/issues"

--- a/packages/graphql-request/package.json
+++ b/packages/graphql-request/package.json
@@ -30,7 +30,8 @@
     "copy-readme": "cp ../../docs/graphql-request.md ./README.md",
     "build": "tsc --build tsconfig.build.json",
     "build:watch": "tsc --build tsconfig.build.json --watch",
-    "test": "vitest"
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "bugs": {
     "url": "https://github.com/golevelup/nestjs/issues"

--- a/packages/hasura/package.json
+++ b/packages/hasura/package.json
@@ -28,7 +28,8 @@
     "copy-readme": "cp ../../docs/modules/hasura.md ./README.md",
     "build": "tsc --build tsconfig.build.json",
     "build:watch": "tsc --build tsconfig.build.json --watch",
-    "test": "jest"
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
   },
   "bugs": {
     "url": "https://github.com/golevelup/nestjs/issues"

--- a/packages/modules/package.json
+++ b/packages/modules/package.json
@@ -25,7 +25,8 @@
     "copy-readme": "cp ../../docs/modules.md ./README.md",
     "build": "tsc --build tsconfig.build.json",
     "build:watch": "tsc --build tsconfig.build.json --watch",
-    "test": "jest"
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
   },
   "bugs": {
     "url": "https://github.com/golevelup/nestjs/issues"

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -29,7 +29,8 @@
     "copy-readme": "cp ../../docs/modules/rabbitmq.md ./README.md",
     "build": "tsc --build tsconfig.build.json",
     "build:watch": "tsc --build tsconfig.build.json --watch",
-    "test": "jest"
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
   },
   "bugs": {
     "url": "https://github.com/golevelup/nestjs/issues"

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -28,7 +28,8 @@
     "copy-readme": "cp ../../docs/modules/stripe.md ./README.md",
     "build": "tsc --build tsconfig.build.json",
     "build:watch": "tsc --build tsconfig.build.json --watch",
-    "test": "jest"
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
   },
   "bugs": {
     "url": "https://github.com/golevelup/nestjs/issues"

--- a/packages/testing/ts-jest/package.json
+++ b/packages/testing/ts-jest/package.json
@@ -28,7 +28,8 @@
     "copy-readme": "cp ../../../docs/testing/ts-jest.md ./README.md",
     "build": "tsc --build tsconfig.build.json",
     "build:watch": "tsc --build tsconfig.build.json --watch",
-    "test": "jest"
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
   },
   "bugs": {
     "url": "https://github.com/golevelup/nestjs/issues"

--- a/packages/testing/ts-sinon/package.json
+++ b/packages/testing/ts-sinon/package.json
@@ -29,7 +29,8 @@
     "copy-readme": "cp ../../../docs/testing/ts-sinon.md ./README.md",
     "build": "tsc --build tsconfig.build.json",
     "build:watch": "tsc --build tsconfig.build.json --watch",
-    "test": "jest"
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
   },
   "bugs": {
     "url": "https://github.com/golevelup/nestjs/issues"

--- a/packages/testing/ts-vitest/package.json
+++ b/packages/testing/ts-vitest/package.json
@@ -31,7 +31,8 @@
     "copy-readme": "cp ../../../docs/testing/ts-vitest.md ./README.md",
     "build": "tsc --build tsconfig.build.json",
     "build:watch": "tsc --build tsconfig.build.json --watch",
-    "test": "vitest"
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "bugs": {
     "url": "https://github.com/golevelup/nestjs/issues"

--- a/packages/testing/ts-vitest/src/type-helper.ts
+++ b/packages/testing/ts-vitest/src/type-helper.ts
@@ -44,9 +44,7 @@ export type IsExactlyUnknown<T> = unknown extends T
 export type DeepMockedFunction<T extends (...args: any[]) => any> = ((
   ...args: Parameters<T>
 ) => DeepMocked<ReturnType<T>>) &
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  Mock<Parameters<T>>;
+  Mock<T>;
 
 /**
  * Recursively transforms a type into a deeply mocked version.
@@ -82,4 +80,4 @@ export type DeepMocked<T> = {
           ? DeepMocked<NonNullable<T[K]>> | undefined
           : DeepMocked<T[K]>
         : T[K]; // primitive
-};
+} & T;

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -30,7 +30,8 @@
     "copy-readme": "cp ../../docs/webhooks.md ./README.md",
     "build": "tsc --build tsconfig.build.json",
     "build:watch": "tsc --build tsconfig.build.json --watch",
-    "test": "jest"
+    "test": "jest",
+    "typecheck": "tsc --noEmit"
   },
   "bugs": {
     "url": "https://github.com/golevelup/nestjs/issues"


### PR DESCRIPTION
This PR fixes incorrect type definitions in `@golevelup/ts-vitest` that caused `mockResolvedValueOnce` and similar methods to have `never` types, and adds a typecheck CI step to catch type errors in test files.

## Type Fix

The `DeepMockedFunction` type was using `Mock<Parameters<T>>` but Vitest's `Mock` takes the full function type, so it should be `Mock<T>`. Additionally, `DeepMocked<T>` was missing the `& T` intersection that exists in the ts-jest version, which prevented mocks from being assignable to original types when private fields were present.

## CI

While adding a regression test for this fix, I discovered that the existing test suite already exercises these types extensively. Running `tsc` on the spec files revealed 7 type errors that were going unnoticed because `tsconfig.build.json` excludes `*.spec.ts`. Rather than adding another test, enabling type checking for test files in CI made more sense. This PR adds a `typecheck` script to all packages and a "Lint & Typecheck" step to the CI workflow.