### PR TITLE
fix(rabbitmq): multiplex shared RPC queue by routing key

### DIFF
--- a/integration/rabbitmq/e2e/rpc.e2e-spec.ts
+++ b/integration/rabbitmq/e2e/rpc.e2e-spec.ts
@@ -118,4 +118,48 @@ describe('Rabbit RPC', () => {
 
     expect(response).toEqual({ echo: '{a:' });
   });
+
+  it('should route to correct handler when RPC handlers share a queue', async () => {
+    const response = await amqpConnection.request({
+      exchange: 'exchange1',
+      routingKey: 'shared-rpc-1',
+      payload: { test: 'handler1' },
+    });
+
+    expect(response).toEqual({
+      echo: { test: 'handler1' },
+      handler: 'shared-rpc-1',
+    });
+  });
+
+  it('should route to second handler on shared queue', async () => {
+    const response = await amqpConnection.request({
+      exchange: 'exchange1',
+      routingKey: 'shared-rpc-2',
+      payload: { test: 'handler2' },
+    });
+
+    expect(response).toEqual({
+      echo: { test: 'handler2' },
+      handler: 'shared-rpc-2',
+    });
+  });
+
+  it('should handle parallel requests to shared queue handlers', async () => {
+    const [res1, res2] = await Promise.all([
+      amqpConnection.request({
+        exchange: 'exchange1',
+        routingKey: 'shared-rpc-1',
+        payload: { n: 1 },
+      }),
+      amqpConnection.request({
+        exchange: 'exchange1',
+        routingKey: 'shared-rpc-2',
+        payload: { n: 2 },
+      }),
+    ]);
+
+    expect(res1).toEqual({ echo: { n: 1 }, handler: 'shared-rpc-1' });
+    expect(res2).toEqual({ echo: { n: 2 }, handler: 'shared-rpc-2' });
+  });
 });

--- a/integration/rabbitmq/src/named-connection/named-connection.controller.ts
+++ b/integration/rabbitmq/src/named-connection/named-connection.controller.ts
@@ -68,7 +68,7 @@ export class NamedConnectionController {
     connection: CONNECTION_NAME,
     routingKey: 'piped-rpc-2',
     exchange: 'exchange3',
-    queue: 'piped-rpc-2',
+    queue: 'piped-rpc-3',
     errorBehavior: MessageHandlerErrorBehavior.ACK,
     errorHandler: ReplyErrorCallback,
   })
@@ -83,7 +83,7 @@ export class NamedConnectionController {
     connection: CONNECTION_NAME,
     routingKey: 'piped-param-rpc-2',
     exchange: 'exchange3',
-    queue: 'piped-param-rpc-2',
+    queue: 'piped-param-rpc-3',
     errorBehavior: MessageHandlerErrorBehavior.ACK,
     errorHandler: ReplyErrorCallback,
   })
@@ -97,7 +97,7 @@ export class NamedConnectionController {
     connection: CONNECTION_NAME,
     routingKey: 'guarded-rpc-2',
     exchange: 'exchange3',
-    queue: 'guarded-rpc-2',
+    queue: 'guarded-rpc-3',
     errorBehavior: MessageHandlerErrorBehavior.ACK,
     errorHandler: ReplyErrorCallback,
   })
@@ -112,7 +112,7 @@ export class NamedConnectionController {
     connection: CONNECTION_NAME,
     routingKey: 'error-reply-rpc-2',
     exchange: 'exchange3',
-    queue: 'error-reply-rpc-2',
+    queue: 'error-reply-rpc-3',
     errorBehavior: MessageHandlerErrorBehavior.ACK,
     errorHandler: ReplyErrorCallback,
   })
@@ -124,7 +124,7 @@ export class NamedConnectionController {
     connection: CONNECTION_NAME,
     routingKey: 'non-json-rpc-2',
     exchange: 'exchange3',
-    queue: 'non-json-rpc-2',
+    queue: 'non-json-rpc-3',
     allowNonJsonMessages: true,
   })
   nonJsonRpc(nonJsonMessage: any) {

--- a/integration/rabbitmq/src/rpc/rpc.service.ts
+++ b/integration/rabbitmq/src/rpc/rpc.service.ts
@@ -73,4 +73,28 @@ export class RpcService {
       echo: nonJsonMessage,
     };
   }
+
+  @RabbitRPC({
+    routingKey: 'shared-rpc-1',
+    exchange: 'exchange1',
+    queue: 'shared-rpc-queue',
+  })
+  sharedRpc1(message: object) {
+    return {
+      echo: message,
+      handler: 'shared-rpc-1',
+    };
+  }
+
+  @RabbitRPC({
+    routingKey: 'shared-rpc-2',
+    exchange: 'exchange1',
+    queue: 'shared-rpc-queue',
+  })
+  sharedRpc2(message: object) {
+    return {
+      echo: message,
+      handler: 'shared-rpc-2',
+    };
+  }
 }

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -147,6 +147,15 @@ export class AmqpConnection {
   private _consumers: Record<ConsumerTag, ConsumerHandler<unknown, unknown>> =
     {};
 
+  private _rpcHandlersByQueue = new Map<
+    string,
+    Array<{
+      routingKey: string | string[];
+      handler: RpcSubscriberHandler<any, any>;
+      rpcOptions: MessageHandlerOptions;
+    }>
+  >();
+
   private readonly config: Required<RabbitMQConfig>;
 
   private readonly outstandingMessageProcessing = new Set<Promise<void>>();
@@ -753,13 +762,102 @@ export class AmqpConnection {
     }
   }
 
+  private findRpcHandler(
+    handlers: Array<{
+      routingKey: string | string[];
+      handler: RpcSubscriberHandler<any, any>;
+      rpcOptions: MessageHandlerOptions;
+    }>,
+    routingKey: string,
+  ) {
+    for (const entry of handlers) {
+      const keys = Array.isArray(entry.routingKey)
+        ? entry.routingKey
+        : [entry.routingKey];
+      if (keys.includes(routingKey)) {
+        return entry;
+      }
+    }
+    for (const entry of handlers) {
+      if (matchesRoutingKey(routingKey, entry.routingKey)) {
+        return entry;
+      }
+    }
+    return null;
+  }
+
+  private validateSharedQueueOptions(
+    queueName: string,
+    newOptions: MessageHandlerOptions,
+  ) {
+    const existing = this._rpcHandlersByQueue.get(queueName);
+    if (!existing || existing.length === 0) return;
+
+    const first = existing[0].rpcOptions;
+
+    if (first.exchange !== newOptions.exchange) {
+      throw new Error(
+        `RPC handler conflict on queue "${queueName}": ` +
+          `exchange "${newOptions.exchange}" does not match ` +
+          `already registered exchange "${first.exchange}". ` +
+          `All @RabbitRPC handlers sharing a queue must use the same exchange.`,
+      );
+    }
+
+    const existingConsumerOpts = JSON.stringify(
+      first.queueOptions?.consumerOptions ?? {},
+    );
+    const newConsumerOpts = JSON.stringify(
+      newOptions.queueOptions?.consumerOptions ?? {},
+    );
+    if (existingConsumerOpts !== newConsumerOpts) {
+      throw new Error(
+        `RPC handler conflict on queue "${queueName}": ` +
+          `consumerOptions do not match between handlers. ` +
+          `All @RabbitRPC handlers sharing a queue must use the same consumerOptions.`,
+      );
+    }
+  }
+
   public async createRpc<T, U>(
     handler: RpcSubscriberHandler<T, U>,
     rpcOptions: MessageHandlerOptions,
   ): Promise<SubscriptionResult> {
-    return this.consumerFactory(rpcOptions, (channel, channelRpcOptions) =>
-      this.setupRpcChannel<T, U>(handler, channelRpcOptions, channel),
-    );
+    const queueName = rpcOptions.queue;
+
+    if (!queueName) {
+      return this.consumerFactory(rpcOptions, (channel, channelRpcOptions) =>
+        this.setupRpcChannel<T, U>(handler, channelRpcOptions, channel),
+      );
+    }
+
+    this.validateSharedQueueOptions(queueName, rpcOptions);
+
+    if (!this._rpcHandlersByQueue.has(queueName)) {
+      this._rpcHandlersByQueue.set(queueName, []);
+    }
+    this._rpcHandlersByQueue.get(queueName)!.push({
+      routingKey: rpcOptions.routingKey!,
+      handler,
+      rpcOptions,
+    });
+
+    if (this._rpcHandlersByQueue.get(queueName)!.length === 1) {
+      return this.consumerFactory(rpcOptions, (channel, channelRpcOptions) =>
+        this.setupRpcChannel<T, U>(handler, channelRpcOptions, channel),
+      );
+    }
+
+    return new Promise((res) => {
+      this.selectManagedChannel(rpcOptions?.queueOptions?.channel).addSetup(
+        async (channel: ConfirmChannel) => {
+          await this.setupQueue(rpcOptions, channel);
+          res({
+            consumerTag: `shared-rpc-${queueName}-${this._rpcHandlersByQueue.get(queueName)!.length}`,
+          });
+        },
+      );
+    });
   }
 
   public async setupRpcChannel<T, U>(
@@ -767,29 +865,64 @@ export class AmqpConnection {
     rpcOptions: MessageHandlerOptions,
     channel: ConfirmChannel,
   ): Promise<ConsumerTag> {
-    const queue = await this.setupQueue(rpcOptions, channel);
+    const queueName = rpcOptions.queue;
+    const handlers = queueName ? this._rpcHandlersByQueue.get(queueName) : null;
+
+    let resolvedQueue: string;
+    if (handlers && handlers.length > 0) {
+      for (const entry of handlers) {
+        resolvedQueue = await this.setupQueue(entry.rpcOptions, channel);
+      }
+    } else {
+      resolvedQueue = await this.setupQueue(rpcOptions, channel);
+    }
 
     const { consumerTag }: { consumerTag: ConsumerTag } = await channel.consume(
-      queue,
+      resolvedQueue!,
       this.wrapConsumer(async (msg) => {
         try {
           if (msg == null) {
             throw new NullMessageError();
           }
 
-          if (
-            !matchesRoutingKey(msg.fields.routingKey, rpcOptions.routingKey)
-          ) {
-            channel.nack(msg, false, false);
-            this.logger.error(
-              'Received message with invalid routing key: ' +
-                msg.fields.routingKey,
+          let matchedHandler: RpcSubscriberHandler<any, any>;
+          let matchedOptions: MessageHandlerOptions;
+
+          if (handlers && handlers.length > 0) {
+            const matched = this.findRpcHandler(
+              handlers,
+              msg.fields.routingKey,
             );
-            return;
+            if (!matched) {
+              channel.nack(msg, false, false);
+              this.logger.error(
+                `No RPC handler found for routing key "${msg.fields.routingKey}" on queue "${queueName}"`,
+              );
+              return;
+            }
+            matchedHandler = matched.handler;
+            matchedOptions = matched.rpcOptions;
+          } else {
+            if (
+              !matchesRoutingKey(msg.fields.routingKey, rpcOptions.routingKey)
+            ) {
+              channel.nack(msg, false, false);
+              this.logger.error(
+                'Received message with invalid routing key: ' +
+                  msg.fields.routingKey,
+              );
+              return;
+            }
+            matchedHandler = handler;
+            matchedOptions = rpcOptions;
           }
 
-          const result = this.deserializeMessage<T>(msg, rpcOptions);
-          const response = await handler(result.message, msg, result.headers);
+          const result = this.deserializeMessage<T>(msg, matchedOptions);
+          const response = await matchedHandler(
+            result.message,
+            msg,
+            result.headers,
+          );
 
           if (response instanceof Nack) {
             channel.nack(msg, false, response.requeue);
@@ -803,7 +936,7 @@ export class AmqpConnection {
               correlationId,
               expiration,
               headers,
-              persistent: rpcOptions.usePersistentReplyTo ?? false,
+              persistent: matchedOptions.usePersistentReplyTo ?? false,
             });
           }
           channel.ack(msg);
@@ -811,11 +944,17 @@ export class AmqpConnection {
           if (msg == null) {
             return;
           } else {
+            const matchedOptions =
+              handlers && handlers.length > 0
+                ? (this.findRpcHandler(handlers, msg.fields.routingKey)
+                    ?.rpcOptions ?? rpcOptions)
+                : rpcOptions;
+
             const errorHandler =
-              rpcOptions.errorHandler ||
+              matchedOptions.errorHandler ||
               this.config.defaultRpcErrorHandler ||
               getHandlerForLegacyBehavior(
-                rpcOptions.errorBehavior ||
+                matchedOptions.errorBehavior ||
                   this.config.defaultSubscribeErrorBehavior,
               );
 

--- a/packages/rabbitmq/src/amqp/connection.ts
+++ b/packages/rabbitmq/src/amqp/connection.ts
@@ -42,7 +42,7 @@ import {
   RpcTimeoutError,
 } from './errors';
 import { Nack, RpcResponse, SubscribeResponse } from './handlerResponses';
-import { isNull, merge } from 'lodash';
+import { isEqual, isNull, merge } from 'lodash';
 import { matchesRoutingKey } from './utils';
 
 const DIRECT_REPLY_QUEUE = 'amq.rabbitmq.reply-to';
@@ -155,6 +155,8 @@ export class AmqpConnection {
       rpcOptions: MessageHandlerOptions;
     }>
   >();
+
+  private _rpcConsumerTagByQueue = new Map<string, ConsumerTag>();
 
   private readonly config: Required<RabbitMQConfig>;
 
@@ -804,13 +806,23 @@ export class AmqpConnection {
       );
     }
 
-    const existingConsumerOpts = JSON.stringify(
-      first.queueOptions?.consumerOptions ?? {},
-    );
-    const newConsumerOpts = JSON.stringify(
-      newOptions.queueOptions?.consumerOptions ?? {},
-    );
-    if (existingConsumerOpts !== newConsumerOpts) {
+    const firstChannel = first.queueOptions?.channel;
+    const newChannel = newOptions.queueOptions?.channel;
+    if (firstChannel !== newChannel) {
+      throw new Error(
+        `RPC handler conflict on queue "${queueName}": ` +
+          `channel "${newChannel}" does not match ` +
+          `already registered channel "${firstChannel}". ` +
+          `All @RabbitRPC handlers sharing a queue must use the same channel.`,
+      );
+    }
+
+    if (
+      !isEqual(
+        first.queueOptions?.consumerOptions ?? {},
+        newOptions.queueOptions?.consumerOptions ?? {},
+      )
+    ) {
       throw new Error(
         `RPC handler conflict on queue "${queueName}": ` +
           `consumerOptions do not match between handlers. ` +
@@ -848,13 +860,33 @@ export class AmqpConnection {
       );
     }
 
-    return new Promise((res) => {
+    const existingTag = this._rpcConsumerTagByQueue.get(queueName);
+    if (existingTag) {
+      return new Promise((res, rej) => {
+        this.selectManagedChannel(rpcOptions?.queueOptions?.channel).addSetup(
+          async (channel: ConfirmChannel) => {
+            try {
+              await this.setupQueue(rpcOptions, channel);
+              res({ consumerTag: existingTag });
+            } catch (error) {
+              rej(error);
+              throw error;
+            }
+          },
+        );
+      });
+    }
+
+    return new Promise((res, rej) => {
       this.selectManagedChannel(rpcOptions?.queueOptions?.channel).addSetup(
         async (channel: ConfirmChannel) => {
-          await this.setupQueue(rpcOptions, channel);
-          res({
-            consumerTag: `shared-rpc-${queueName}-${this._rpcHandlersByQueue.get(queueName)!.length}`,
-          });
+          try {
+            await this.setupQueue(rpcOptions, channel);
+            res({ consumerTag: `shared-rpc-${queueName}` });
+          } catch (error) {
+            rej(error);
+            throw error;
+          }
         },
       );
     });
@@ -870,8 +902,9 @@ export class AmqpConnection {
 
     let resolvedQueue: string;
     if (handlers && handlers.length > 0) {
-      for (const entry of handlers) {
-        resolvedQueue = await this.setupQueue(entry.rpcOptions, channel);
+      resolvedQueue = await this.setupQueue(handlers[0].rpcOptions, channel);
+      for (let i = 1; i < handlers.length; i++) {
+        await this.setupQueue(handlers[i].rpcOptions, channel);
       }
     } else {
       resolvedQueue = await this.setupQueue(rpcOptions, channel);
@@ -964,6 +997,10 @@ export class AmqpConnection {
       }),
       rpcOptions?.queueOptions?.consumerOptions,
     );
+
+    if (queueName && handlers && handlers.length > 0) {
+      this._rpcConsumerTagByQueue.set(queueName, consumerTag);
+    }
 
     this.registerConsumerForQueue({
       type: 'rpc',

--- a/packages/rabbitmq/src/tests/amqp.connection.spec.ts
+++ b/packages/rabbitmq/src/tests/amqp.connection.spec.ts
@@ -22,6 +22,7 @@ describe('AmqpConnection', () => {
   let connection: AmqpConnection;
 
   beforeEach(async () => {
+    jest.clearAllMocks();
     jest
       .spyOn(AmqpConnection.prototype as any, 'selectManagedChannel')
       .mockReturnValue({
@@ -33,6 +34,9 @@ describe('AmqpConnection', () => {
     jest
       .spyOn(AmqpConnection.prototype as any, 'setupRpcChannel')
       .mockReturnValue(mockConsumerTag);
+    jest
+      .spyOn(AmqpConnection.prototype as any, 'setupQueue')
+      .mockResolvedValue('test-queue');
 
     connection = new AmqpConnection(mockConfig);
   });
@@ -109,5 +113,55 @@ describe('AmqpConnection', () => {
       },
       mockChannel,
     );
+  });
+
+  it('should throw when shared queue handlers use different exchanges', async () => {
+    const mockHandler = jest.fn();
+    await connection.createRpc(mockHandler, {
+      queue: 'test-queue',
+      exchange: 'exchange-a',
+      routingKey: 'key1',
+    });
+    await expect(
+      connection.createRpc(mockHandler, {
+        queue: 'test-queue',
+        exchange: 'exchange-b',
+        routingKey: 'key2',
+      }),
+    ).rejects.toThrow(/exchange.*does not match/);
+  });
+
+  it('should throw when shared queue handlers use different consumerOptions', async () => {
+    const mockHandler = jest.fn();
+    await connection.createRpc(mockHandler, {
+      queue: 'test-queue',
+      exchange: 'exchange1',
+      routingKey: 'key1',
+      queueOptions: { consumerOptions: { priority: 1 } },
+    });
+    await expect(
+      connection.createRpc(mockHandler, {
+        queue: 'test-queue',
+        exchange: 'exchange1',
+        routingKey: 'key2',
+        queueOptions: { consumerOptions: { priority: 5 } },
+      }),
+    ).rejects.toThrow(/consumerOptions do not match/);
+  });
+
+  it('should only call setupRpcChannel once for shared queue', async () => {
+    const mockHandler = jest.fn();
+    await connection.createRpc(mockHandler, {
+      queue: 'shared-queue',
+      exchange: 'exchange1',
+      routingKey: 'key1',
+    });
+    await connection.createRpc(mockHandler, {
+      queue: 'shared-queue',
+      exchange: 'exchange1',
+      routingKey: 'key2',
+    });
+
+    expect(connection['setupRpcChannel']).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Fixes #751

When multiple `@RabbitRPC` handlers share the same named queue with different
routing keys, messages could be dropped due to round-robin delivery across
competing consumers and routing-key mismatch handling.

This change creates a single consumer per shared named queue and dispatches
messages internally by matching `msg.fields.routingKey` to the correct handler.

- Exact routing key match takes priority over pattern match
- Exchange and consumerOptions conflicts on shared queues are detected at startup
- Handlers without a named queue keep the existing behavior (one consumer each)
- Reconnect safe: `addSetup` restores all bindings for the shared queue

Also updates `NamedConnectionController` integration test queue names to avoid a
pre-existing exchange conflict that the new validation now correctly detects.