### PR TITLE
refactor(discovery): use native Javascript functions #1237

### DIFF
--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -34,7 +34,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "lodash": "^4.18.1"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.1.21",

--- a/packages/discovery/src/advanced-controller-discovery.spec.ts
+++ b/packages/discovery/src/advanced-controller-discovery.spec.ts
@@ -61,6 +61,34 @@ class AdminController {
 })
 class ExampleModule {}
 
+function createDuplicateController(path: string, response: string) {
+  @Controller(path)
+  @Roles(['guest'])
+  class DuplicateController {
+    @Get(response)
+    method() {
+      return response;
+    }
+  }
+
+  return DuplicateController;
+}
+
+const DuplicateControllerOne = createDuplicateController(
+  'duplicate-one',
+  'duplicate-route-one',
+);
+const DuplicateControllerTwo = createDuplicateController(
+  'duplicate-two',
+  'duplicate-route-two',
+);
+
+@Module({
+  imports: [DiscoveryModule],
+  controllers: [DuplicateControllerOne, DuplicateControllerTwo],
+})
+class DuplicateControllerModule {}
+
 describe('Advanced Controller Discovery', () => {
   let app: TestingModule;
   let discover: DiscoveryService;
@@ -147,5 +175,42 @@ describe('Advanced Controller Discovery', () => {
       verb: RequestMethod.PUT,
       path: 'guest/some-put-route',
     });
+  });
+
+  it('deduplicates methods by handler identity', async () => {
+    const duplicateApp = await Test.createTestingModule({
+      imports: [DuplicateControllerModule],
+    }).compile();
+
+    await duplicateApp.init();
+
+    const duplicateDiscover =
+      duplicateApp.get<DiscoveryService>(DiscoveryService);
+
+    const methods =
+      await duplicateDiscover.methodsAndControllerMethodsWithMetaAtKey<
+        string[]
+      >(rolesKey, (x) => x.includes('guest'));
+
+    expect(methods).toHaveLength(2);
+
+    const fullPaths = methods.map((x) => {
+      const controllerPath = getComponentMetaAtKey<string>(
+        PATH_METADATA,
+        x.discoveredMethod.parentClass,
+      );
+
+      const methodPath = Reflect.getMetadata(
+        PATH_METADATA,
+        x.discoveredMethod.handler,
+      );
+
+      return `${controllerPath}/${methodPath}`;
+    });
+
+    expect(fullPaths).toContain('duplicate-one/duplicate-route-one');
+    expect(fullPaths).toContain('duplicate-two/duplicate-route-two');
+
+    await duplicateApp.close();
   });
 });

--- a/packages/discovery/src/discovery.service.ts
+++ b/packages/discovery/src/discovery.service.ts
@@ -98,12 +98,12 @@ export class DiscoveryService {
       await this.controllerMethodsWithMetaAtKey<T>(metaKey)
     ).filter((x) => metaFilter(x.meta));
 
-    const uniqueMethods = new Map();
+    const uniqueMethods = new Map<Function, DiscoveredMethodWithMeta<T>>();
     [...methodsFromDecoratedControllers, ...decoratedMethods].forEach(
       (method) => {
-        const methodIdentifier = `${method.discoveredMethod.parentClass.name}#${method.discoveredMethod.methodName}`;
-        if (!uniqueMethods.has(methodIdentifier)) {
-          uniqueMethods.set(methodIdentifier, method);
+        const { handler } = method.discoveredMethod;
+        if (!uniqueMethods.has(handler)) {
+          uniqueMethods.set(handler, method);
         }
       },
     );

--- a/packages/discovery/src/discovery.service.ts
+++ b/packages/discovery/src/discovery.service.ts
@@ -175,7 +175,7 @@ export class DiscoveryService {
       .map((name) =>
         this.extractMethodMetaAtKey<T>(metaKey, component, prototype, name),
       )
-      .filter((x) => !!x.meta);
+      .filter((x) => x.meta !== null && x.meta !== undefined);
   }
 
   /**

--- a/packages/discovery/src/discovery.service.ts
+++ b/packages/discovery/src/discovery.service.ts
@@ -45,7 +45,7 @@ export const withMetaAtKey: (key: MetaKey) => Filter<DiscoveredClass> =
     const metaTargets: Function[] = [
       component?.instance?.constructor,
       component.injectType as Function,
-    ].filter((x) => !!x);
+    ].filter((x) => x != null);
 
     return metaTargets.some((x) => Reflect.getMetadata(key, x));
   };
@@ -175,7 +175,7 @@ export class DiscoveryService {
       .map((name) =>
         this.extractMethodMetaAtKey<T>(metaKey, component, prototype, name),
       )
-      .filter((x) => x.meta !== null && x.meta !== undefined);
+      .filter((x) => x.meta != null);
   }
 
   /**

--- a/packages/discovery/src/discovery.service.ts
+++ b/packages/discovery/src/discovery.service.ts
@@ -4,7 +4,6 @@ import { PATH_METADATA } from '@nestjs/common/constants';
 import { STATIC_CONTEXT } from '@nestjs/core/injector/constants';
 import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { Module } from '@nestjs/core/injector/module';
-import { flatMap, get, isNil, some, uniqBy } from 'lodash';
 import {
   DiscoveredClass,
   DiscoveredClassWithMeta,
@@ -44,11 +43,11 @@ export function getComponentMetaAtKey<T>(
 export const withMetaAtKey: (key: MetaKey) => Filter<DiscoveredClass> =
   (key) => (component) => {
     const metaTargets: Function[] = [
-      get(component, 'instance.constructor') as any,
+      component?.instance?.constructor,
       component.injectType as Function,
-    ].filter((x) => !isNil(x));
+    ].filter((x) => !!x);
 
-    return some(metaTargets, (x) => Reflect.getMetadata(key, x));
+    return metaTargets.some((x) => Reflect.getMetadata(key, x));
   };
 
 @Injectable()
@@ -86,8 +85,7 @@ export class DiscoveryService {
       await this.controllersWithMetaAtKey<T>(metaKey)
     ).filter((x) => metaFilter(x.meta));
 
-    const methodsFromDecoratedControllers = flatMap(
-      controllersWithMeta,
+    const methodsFromDecoratedControllers = controllersWithMeta.flatMap(
       (controller) => {
         return this.classMethodsWithMetaAtKey<T>(
           controller.discoveredClass,
@@ -100,10 +98,16 @@ export class DiscoveryService {
       await this.controllerMethodsWithMetaAtKey<T>(metaKey)
     ).filter((x) => metaFilter(x.meta));
 
-    return uniqBy(
-      [...methodsFromDecoratedControllers, ...decoratedMethods],
-      (x) => x.discoveredMethod.handler,
+    const uniqueMethods = new Map();
+    [...methodsFromDecoratedControllers, ...decoratedMethods].forEach(
+      (method) => {
+        const methodIdentifier = `${method.discoveredMethod.parentClass.name}#${method.discoveredMethod.methodName}`;
+        if (!uniqueMethods.has(methodIdentifier)) {
+          uniqueMethods.set(methodIdentifier, method);
+        }
+      },
     );
+    return Array.from(uniqueMethods.values());
   }
 
   /**
@@ -171,7 +175,7 @@ export class DiscoveryService {
       .map((name) =>
         this.extractMethodMetaAtKey<T>(metaKey, component, prototype, name),
       )
-      .filter((x) => !isNil(x.meta));
+      .filter((x) => !!x.meta);
   }
 
   /**
@@ -185,7 +189,7 @@ export class DiscoveryService {
   ): Promise<DiscoveredMethodWithMeta<T>[]> {
     const providers = await this.providers(providerFilter);
 
-    return flatMap(providers, (provider) =>
+    return providers.flatMap((provider) =>
       this.classMethodsWithMetaAtKey<T>(provider, metaKey),
     );
   }
@@ -201,7 +205,7 @@ export class DiscoveryService {
   ): Promise<DiscoveredMethodWithMeta<T>[]> {
     const controllers = await this.controllers(controllerFilter);
 
-    return flatMap(controllers, (controller) =>
+    return controllers.flatMap((controller) =>
       this.classMethodsWithMetaAtKey<T>(controller, metaKey),
     );
   }
@@ -224,7 +228,7 @@ export class DiscoveryService {
       instance: instanceHost.instance,
       // TODO: remove nullish coalescing operator to return undefined when dropping NestJS 10 support
       injectType: wrapper.metatype ?? undefined,
-      dependencyType: get(instanceHost, 'instance.constructor'),
+      dependencyType: instanceHost?.instance?.constructor,
       parentModule: {
         name: nestModule.metatype.name,
         instance: nestModule.instance,
@@ -257,7 +261,7 @@ export class DiscoveryService {
     const modulesMap = [...this.modulesContainer.entries()];
     return Promise.all(
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      flatMap(modulesMap, ([key, nestModule]) => {
+      modulesMap.flatMap(([key, nestModule]) => {
         const components = [...nestModule[component].values()];
         return components
           .filter((component) => component.scope !== Scope.REQUEST)

--- a/packages/discovery/src/discovery.spec.ts
+++ b/packages/discovery/src/discovery.spec.ts
@@ -16,6 +16,8 @@ const ExampleClassSymbol = Symbol('ExampleClassSymbol');
 
 const ExampleMethodSymbol = Symbol('ExampleMethodSymbol');
 
+const FalsyMethodSymbol = Symbol('FalsyMethodSymbol');
+
 const NullProviderSymbol = Symbol('NullProvider');
 
 const ExampleClassDecorator = (config: any) =>
@@ -46,6 +48,12 @@ class ExampleController {
   @ExampleMethodDecorator('example controller method meta')
   public get() {
     return 42;
+  }
+
+  @Get('falsy-route')
+  @SetMetadata(FalsyMethodSymbol, false)
+  public falsyMeta() {
+    return false;
   }
 }
 
@@ -149,12 +157,13 @@ describe('Discovery', () => {
         await discoveryService.controllerMethodsWithMetaAtKey<string>(
           PATH_METADATA,
         );
-      const [first] = controllerMethodMeta;
-      expect(first).toBeDefined();
+      expect(controllerMethodMeta.length).toBe(2);
 
-      expect(controllerMethodMeta.length).toBe(1);
+      const meta = controllerMethodMeta.find(
+        (method) => method.discoveredMethod.methodName === 'get',
+      );
 
-      const meta = controllerMethodMeta[0];
+      expect(meta).toBeDefined();
 
       expect(meta).toMatchObject({
         meta: 'route',
@@ -172,9 +181,24 @@ describe('Discovery', () => {
         },
       });
 
-      expect(meta.discoveredMethod.parentClass.instance).toBeInstanceOf(
+      expect(meta?.discoveredMethod.parentClass.instance).toBeInstanceOf(
         ExampleController,
       );
+    });
+
+    it('should preserve falsy method metadata values', async () => {
+      const controllerMethodMeta =
+        await discoveryService.controllerMethodsWithMetaAtKey<boolean>(
+          FalsyMethodSymbol,
+        );
+
+      expect(controllerMethodMeta).toHaveLength(1);
+      expect(controllerMethodMeta[0]).toMatchObject({
+        meta: false,
+        discoveredMethod: {
+          methodName: 'falsyMeta',
+        },
+      });
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,9 +225,6 @@ importers:
       '@nestjs/core':
         specifier: ^11.1.21
         version: 11.1.21(@nestjs/common@11.1.21(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      lodash:
-        specifier: ^4.18.1
-        version: 4.18.1
 
   packages/google-cloud-pubsub:
     dependencies:


### PR DESCRIPTION
Hello 👋 

In this PR, I attempt to replace usage of Lodash with modern Javascript alternatives:

- `get` can be replaced with `?`
- `flatMap(array...)` to `array.flatMap(...)`
- `!isNil` can be replaced with `!!`, coercing the value to boolean
- `uniqBy` can be replaced with a `Map` and a unique key. In the context of `discovery`, I assumed method handlers are unique by name and parent class.

I kept the change minimal only related to the issue. Let me know what you think or I missed.